### PR TITLE
chore: add documentation and security linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,21 @@ version: "2"
 
 linters:
   enable:
+    # Existing
     - gocritic
     - gocyclo
+    # Doc/Comment
+    - godot
+    - godoclint
+    - dupword
+    - misspell
+    # Code quality
+    - errorlint
+    - gosec
+    - nilerr
+    - unparam
+    - unconvert
+    - bodyclose
   settings:
     gocritic:
       enabled-tags:
@@ -12,3 +25,5 @@ linters:
         - performance
     gocyclo:
       min-complexity: 20
+    godot:
+      scope: toplevel

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ type Station struct {
 // Load reads and parses the configuration from a JSON file and applies sensible defaults for missing values.
 func Load(path string) (*Config, error) {
 	// Open file for streaming JSON decoding
-	file, err := os.Open(path)
+	file, err := os.Open(path) //nolint:gosec // Config path is provided by the application, not user input
 	if err != nil {
 		return nil, fmt.Errorf("failed to open config file %q: %w", path, err)
 	}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -36,7 +36,7 @@ func (f *Fetcher) Fetch(url, jsonPath string, parseJSON bool) string {
 	return f.fetchRaw(url)
 }
 
-// fetchURL retrieves raw content from a URL
+// fetchURL retrieves raw content from a URL.
 func (f *Fetcher) fetchURL(url string) ([]byte, error) {
 	resp, err := f.client.Get(url)
 	if err != nil {

--- a/internal/postprocessor/postprocessor.go
+++ b/internal/postprocessor/postprocessor.go
@@ -301,7 +301,7 @@ func (m *Manager) saveRecording(recording *Recording) {
 func (m *Manager) loadRecording(station, hour string) *Recording {
 	recordingFile := utils.RecordingPath(m.recordingsDir, station, hour, ".recording.json")
 
-	data, err := os.ReadFile(recordingFile)
+	data, err := os.ReadFile(recordingFile) //nolint:gosec // Path is constructed from trusted internal values
 	if err != nil {
 		return nil // No recording file
 	}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -1,4 +1,3 @@
-// Package server provides HTTP endpoints for controlling recordings.
 package server
 
 import (

--- a/internal/server/files.go
+++ b/internal/server/files.go
@@ -1,4 +1,3 @@
-// Package server provides HTTP endpoints for controlling recordings.
 package server
 
 import (
@@ -76,7 +75,7 @@ func (s *Server) handleRecordings(w http.ResponseWriter, r *http.Request) {
 }
 
 // showDirectoryListing displays an HTML directory listing.
-func (s *Server) showDirectoryListing(w http.ResponseWriter, r *http.Request, fsPath, urlPath string) {
+func (s *Server) showDirectoryListing(w http.ResponseWriter, _ *http.Request, fsPath, urlPath string) {
 	// Read directory
 	entries, err := os.ReadDir(fsPath)
 	if err != nil {
@@ -119,7 +118,7 @@ func (s *Server) showDirectoryListing(w http.ResponseWriter, r *http.Request, fs
 			fileInfo.Size = "-"
 		} else {
 			fileInfo.URL = "/recordings" + path.Join(urlPath, entry.Name())
-			fileInfo.Size = humanize.Bytes(uint64(info.Size()))
+			fileInfo.Size = humanize.Bytes(uint64(info.Size())) //nolint:gosec // File sizes are always non-negative
 		}
 
 		files = append(files, fileInfo)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1,4 +1,3 @@
-// Package server provides HTTP endpoints for controlling recordings.
 package server
 
 import (

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -1,4 +1,3 @@
-// Package server provides HTTP endpoints for controlling recordings.
 package server
 
 import (

--- a/internal/utils/ffmpeg.go
+++ b/internal/utils/ffmpeg.go
@@ -1,4 +1,3 @@
-// Package utils provides FFmpeg command construction utilities.
 package utils
 
 import (
@@ -20,7 +19,7 @@ func RecordCommand(ctx context.Context, streamURL, duration, outputFile string) 
 		"-y", outputFile,
 	}
 
-	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
+	cmd := exec.CommandContext(ctx, "ffmpeg", args...) //nolint:gosec // Arguments are constructed from trusted config values
 
 	return cmd
 }

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -1,5 +1,5 @@
-// Package utils provides file system utilities for audio recording management,
-// including directory creation, file path construction, and file discovery.
+// Package utils provides file system utilities, FFmpeg command construction,
+// audio format detection, and time utilities for audio recording management.
 package utils
 
 import (

--- a/internal/utils/format.go
+++ b/internal/utils/format.go
@@ -1,4 +1,3 @@
-// Package utils provides audio format detection and content type utilities.
 package utils
 
 import (

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -1,4 +1,3 @@
-// Package utils provides time-related utilities for timestamp formatting and timezone management.
 package utils
 
 import (


### PR DESCRIPTION
## Summary
- Enable additional golangci-lint checks for documentation quality (godot, godoclint, dupword, misspell) and code quality (errorlint, gosec, nilerr, unparam, unconvert, bodyclose)
- Fix all issues found by the new linters:
  - Add periods to comments missing them (godot)
  - Remove duplicate package comments, keeping only one per package (godoclint)
  - Add `//nolint:gosec` comments with reasons for false positives (subprocess commands, file operations with trusted paths)
  - Prefix unused `*http.Request` parameter with `_` (unparam)
  - Update package utils comment to be more comprehensive

## Test plan
- [x] `golangci-lint run --timeout=5m` passes with 0 issues
- [x] `go build` succeeds
- [x] `go vet ./...` passes