### PR TITLE
chore: bump Go from 1.26.0 to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/oszuidwest/zwfm-audiologger
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/pardnchiu/go-cron v1.1.0
 )
 
-require golang.org/x/oauth2 v0.35.0 // indirect
+require golang.org/x/oauth2 v0.35.0


### PR DESCRIPTION
## Summary
- Bump Go version from 1.26.0 to 1.26.1 in go.mod and related files