### PR TITLE
fix: bump Go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oszuidwest/zwfm-audiologger
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/dustin/go-humanize v1.0.1


### PR DESCRIPTION
## Summary

- Bumps the minimum Go version in `go.mod` from `1.26.1` to `1.26.2`.
- Go 1.26.2 is a patch release that fixes security vulnerabilities in the standard library detected by `govulncheck`.

## Background

Running `govulncheck` against this module with Go < 1.26.2 reports vulnerabilities in the following stdlib packages:

- **`crypto/x509`** — certificate parsing issues that can lead to unexpected behaviour or denial of service.
- **`crypto/tls`** — TLS handshake edge-cases that may expose data or allow downgrade attacks.
- **`html/template`** — template injection vectors when user-controlled input reaches certain template constructs.

Upgrading to `go 1.26.2` in `go.mod` ensures that downstream consumers and CI build with the patched toolchain, eliminating these findings.

## Test plan

- [ ] Verify `go build ./...` succeeds with Go 1.26.2 toolchain.
- [ ] Confirm `govulncheck ./...` reports no stdlib vulnerabilities after the bump.
- [ ] Confirm existing CI checks pass on the updated branch.