### PR TITLE
fix: rock-solid recording — catchup, disk guard, failure alerts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,22 +62,17 @@ jobs:
           "linux/amd64"
           "linux/arm64"
           "linux/arm/7"
-          "windows/amd64"
-          "windows/arm64"
           "darwin/amd64"
           "darwin/arm64"
         )
-        
+
         for platform in "${platforms[@]}"; do
           IFS='/' read -r -a array <<< "$platform"
           GOOS=${array[0]}
           GOARCH=${array[1]}
           GOARM=${array[2]}
-          
+
           output_name="audiologger-${{ steps.version.outputs.version }}-${GOOS}-${GOARCH}"
-          if [ "$GOOS" = "windows" ]; then
-            output_name="${output_name}.exe"
-          fi
           
           echo "Building $output_name"
           

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -63,4 +63,12 @@ const (
 	// CatchupGraceSecs is the number of seconds into an hour below which we skip catchup
 	// and let the normal cron job handle the recording.
 	CatchupGraceSecs = 5
+
+	// CatchupMinRemainingSecs is the minimum seconds remaining in an hour to bother
+	// starting a catchup recording. Below this threshold the overhead is not worth it.
+	CatchupMinRemainingSecs = 60
+
+	// AlertNotifyTimeout is the maximum time allowed to deliver a recording failure alert,
+	// including all retries. Bounds the synchronous notify call in the recorder goroutine.
+	AlertNotifyTimeout = 2 * time.Minute
 )

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -60,10 +60,6 @@ const (
 	// MinDiskSpaceBytes is the minimum free disk space required before starting a recording.
 	MinDiskSpaceBytes = uint64(1 * 1024 * 1024 * 1024) // 1 GB
 
-	// CatchupGraceSecs is the number of seconds into an hour below which we skip catchup
-	// and let the normal cron job handle the recording.
-	CatchupGraceSecs = 5
-
 	// CatchupMinRemainingSecs is the minimum seconds remaining in an hour to bother
 	// starting a catchup recording. Below this threshold the overhead is not worth it.
 	CatchupMinRemainingSecs = 60

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -56,4 +56,11 @@ const (
 
 	// ValidationFileSuffix is the file extension for validation result files.
 	ValidationFileSuffix = ".validation.json"
+
+	// MinDiskSpaceBytes is the minimum free disk space required before starting a recording.
+	MinDiskSpaceBytes = uint64(1 * 1024 * 1024 * 1024) // 1 GB
+
+	// CatchupGraceSecs is the number of seconds into an hour below which we skip catchup
+	// and let the normal cron job handle the recording.
+	CatchupGraceSecs = 5
 )

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -78,9 +78,16 @@ func (m *Manager) record(name string, station *config.Station, timestamp, durati
 	}
 
 	// Refuse to record if available disk space is below the minimum threshold.
-	if available, err := utils.AvailableDiskBytes(dir); err != nil {
-		slog.Warn("failed to check disk space, proceeding anyway", "station", name, "error", err)
-	} else if available < constants.MinDiskSpaceBytes {
+	available, err := utils.AvailableDiskBytes(dir)
+	if err != nil {
+		reason := fmt.Sprintf("disk space check failed: %v", err)
+		slog.Error("skipping recording", "station", name, "reason", reason)
+		if m.notifier != nil {
+			m.notifier.NotifyRecordingFailure(name, reason)
+		}
+		return
+	}
+	if available < constants.MinDiskSpaceBytes {
 		reason := fmt.Sprintf("insufficient disk space: %d bytes available, %d required", available, constants.MinDiskSpaceBytes)
 		slog.Error("skipping recording", "station", name, "reason", reason)
 		if m.notifier != nil {

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -54,7 +54,7 @@ func (m *Manager) Scheduled(name string, station *config.Station) {
 		go m.saveMetadata(name, station, timestamp)
 	}
 
-	m.record(name, station, timestamp, constants.HourlyRecordingDuration, constants.HourlyRecordingTimeout)
+	m.record(name, station, timestamp, constants.HourlyRecordingDuration, constants.HourlyRecordingTimeout, false)
 }
 
 // Catchup performs a recording for the remainder of the current hour after a mid-hour startup.
@@ -66,11 +66,13 @@ func (m *Manager) Catchup(name string, station *config.Station, timestamp string
 		go m.saveMetadata(name, station, timestamp)
 	}
 
-	m.record(name, station, timestamp, duration, timeout)
+	// Skip validation: catchup recordings are partial by definition and would
+	// always fail the MinDurationSecs check.
+	m.record(name, station, timestamp, duration, timeout, true)
 }
 
 // record performs the actual recording operation.
-func (m *Manager) record(name string, station *config.Station, timestamp, duration string, timeout time.Duration) {
+func (m *Manager) record(name string, station *config.Station, timestamp, duration string, timeout time.Duration, skipValidation bool) {
 	dir := filepath.Join(m.config.RecordingsDir, name)
 	if err := utils.EnsureDir(dir); err != nil {
 		slog.Error("failed to create directory", "station", name, "error", err, "recordings_dir", m.config.RecordingsDir, "computed_dir", dir)
@@ -164,8 +166,8 @@ func (m *Manager) record(name string, station *config.Station, timestamp, durati
 
 	slog.Info("Recording completed", "file", finalFile, "format", format)
 
-	// Queue recording for validation if validator is configured.
-	if m.validator != nil {
+	// Queue recording for validation if validator is configured and this is a full recording.
+	if m.validator != nil && !skipValidation {
 		m.validator.Enqueue(finalFile, name, timestamp)
 	}
 }
@@ -194,7 +196,7 @@ func (m *Manager) Test() {
 
 	for name, station := range m.config.Stations {
 		timestamp := "test-" + utils.TestTimestamp()
-		m.record(name, &station, timestamp, constants.TestRecordingDuration, constants.TestRecordingTimeout)
+		m.record(name, &station, timestamp, constants.TestRecordingDuration, constants.TestRecordingTimeout, false)
 	}
 
 	slog.Info("Test recordings completed")

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -3,9 +3,11 @@ package recorder
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,19 +22,26 @@ type Validator interface {
 	Enqueue(filePath, station, timestamp string)
 }
 
+// Notifier defines the interface for recording failure notifications.
+type Notifier interface {
+	NotifyRecordingFailure(station, reason string)
+}
+
 // Manager handles recording operations.
 type Manager struct {
 	config          *config.Config
 	metadataFetcher *metadata.Fetcher
 	validator       Validator
+	notifier        Notifier
 }
 
 // New creates a new recording manager.
-func New(cfg *config.Config, validator Validator) *Manager {
+func New(cfg *config.Config, validator Validator, notifier Notifier) *Manager {
 	return &Manager{
 		config:          cfg,
 		metadataFetcher: metadata.New(),
 		validator:       validator,
+		notifier:        notifier,
 	}
 }
 
@@ -48,11 +57,35 @@ func (m *Manager) Scheduled(name string, station *config.Station) {
 	m.record(name, station, timestamp, constants.HourlyRecordingDuration, constants.HourlyRecordingTimeout)
 }
 
+// Catchup performs a recording for the remainder of the current hour after a mid-hour startup.
+func (m *Manager) Catchup(name string, station *config.Station, timestamp string, durationSecs int) {
+	duration := strconv.Itoa(durationSecs)
+	timeout := time.Duration(durationSecs+300) * time.Second // 5-minute buffer beyond duration
+
+	if station.MetadataURL != "" {
+		go m.saveMetadata(name, station, timestamp)
+	}
+
+	m.record(name, station, timestamp, duration, timeout)
+}
+
 // record performs the actual recording operation.
 func (m *Manager) record(name string, station *config.Station, timestamp, duration string, timeout time.Duration) {
 	dir := filepath.Join(m.config.RecordingsDir, name)
 	if err := utils.EnsureDir(dir); err != nil {
 		slog.Error("failed to create directory", "station", name, "error", err, "recordings_dir", m.config.RecordingsDir, "computed_dir", dir)
+		return
+	}
+
+	// Refuse to record if available disk space is below the minimum threshold.
+	if available, err := utils.AvailableDiskBytes(dir); err != nil {
+		slog.Warn("failed to check disk space, proceeding anyway", "station", name, "error", err)
+	} else if available < constants.MinDiskSpaceBytes {
+		reason := fmt.Sprintf("insufficient disk space: %d bytes available, %d required", available, constants.MinDiskSpaceBytes)
+		slog.Error("skipping recording", "station", name, "reason", reason)
+		if m.notifier != nil {
+			m.notifier.NotifyRecordingFailure(name, reason)
+		}
 		return
 	}
 
@@ -80,6 +113,10 @@ func (m *Manager) record(name string, station *config.Station, timestamp, durati
 		}
 		slog.Error("failed recording", "station", name, "error", err, "ffmpeg_command", strings.Join(cmd.Args[1:], " "), "stream_url", station.StreamURL, "output_file", tempFile, "ffmpeg_output", outputStr)
 
+		if m.notifier != nil {
+			m.notifier.NotifyRecordingFailure(name, fmt.Sprintf("FFmpeg failed: %v", err))
+		}
+
 		// Clean up temp file if it was created
 		if err := os.Remove(tempFile); err != nil && !os.IsNotExist(err) {
 			slog.Warn("failed to clean up temp file after error", "file", tempFile, "error", err)
@@ -101,6 +138,10 @@ func (m *Manager) record(name string, station *config.Station, timestamp, durati
 			outputStr = outputStr[:500] + "... (truncated)"
 		}
 		slog.Error("failed to remux recording", "station", name, "temp_file", tempFile, "final_file", finalFile, "error", err, "remux_output", outputStr)
+
+		if m.notifier != nil {
+			m.notifier.NotifyRecordingFailure(name, fmt.Sprintf("remux failed: %v", err))
+		}
 
 		// Clean up temp file when remux fails
 		if err := os.Remove(tempFile); err != nil && !os.IsNotExist(err) {

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -20,6 +20,10 @@ import (
 // Validator defines the interface for recording validation.
 type Validator interface {
 	Enqueue(filePath, station, timestamp string)
+	// MarkSkipped writes a validation sidecar that marks a recording as valid
+	// without running validation checks. Used for catchup recordings so that
+	// scanUnvalidated does not re-queue them on the next startup.
+	MarkSkipped(filePath, station, timestamp string)
 }
 
 // Notifier defines the interface for recording failure notifications.
@@ -166,9 +170,14 @@ func (m *Manager) record(name string, station *config.Station, timestamp, durati
 
 	slog.Info("Recording completed", "file", finalFile, "format", format)
 
-	// Queue recording for validation if validator is configured and this is a full recording.
-	if m.validator != nil && !skipValidation {
-		m.validator.Enqueue(finalFile, name, timestamp)
+	// For full recordings, enqueue for validation. For catchup recordings, write a
+	// sidecar immediately so scanUnvalidated does not re-queue the file on restart.
+	if m.validator != nil {
+		if skipValidation {
+			m.validator.MarkSkipped(finalFile, name, timestamp)
+		} else {
+			m.validator.Enqueue(finalFile, name, timestamp)
+		}
 	}
 }
 

--- a/internal/scheduler/catchup_test.go
+++ b/internal/scheduler/catchup_test.go
@@ -1,0 +1,119 @@
+package scheduler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/oszuidwest/zwfm-audiologger/internal/constants"
+)
+
+func TestCatchupRemaining(t *testing.T) {
+	tests := []struct {
+		name       string
+		minute     int
+		sec        int
+		wantSecs   int
+		wantNeeded bool
+	}{
+		// Start of hour: full catchup, well above the minimum threshold.
+		{"start of hour", 0, 0, 3600, true},
+		// One second in: still needed.
+		{"one second in", 0, 1, 3599, true},
+		// Exactly at the minimum boundary (60 s remaining): still needed.
+		{"at minimum boundary", 59, 0, 60, true},
+		// One second past the minimum (59 s remaining): skip.
+		{"one second past minimum", 59, 1, 59, false},
+		// Near end of hour: definitely skip.
+		{"near end of hour", 59, 59, 1, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Date(2026, 4, 28, 12, tc.minute, tc.sec, 0, time.UTC)
+			gotSecs, gotNeeded := catchupRemaining(now)
+			if gotSecs != tc.wantSecs {
+				t.Errorf("remainingSecs = %d, want %d", gotSecs, tc.wantSecs)
+			}
+			if gotNeeded != tc.wantNeeded {
+				t.Errorf("needed = %v, want %v", gotNeeded, tc.wantNeeded)
+			}
+		})
+	}
+}
+
+func TestExistingAudioFile(t *testing.T) {
+	const ts = "2026-04-28-12"
+
+	t.Run("non-existent dir", func(t *testing.T) {
+		f, err := existingAudioFile(filepath.Join(t.TempDir(), "nodir"), ts)
+		if err != nil {
+			t.Fatalf("unexpected error for non-existent dir: %v", err)
+		}
+		if f != "" {
+			t.Errorf("got %q, want empty string", f)
+		}
+	})
+
+	t.Run("empty dir", func(t *testing.T) {
+		f, err := existingAudioFile(t.TempDir(), ts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if f != "" {
+			t.Errorf("got %q, want empty string", f)
+		}
+	})
+
+	// Side-car files must not be mistaken for audio files.
+	for _, sidecar := range []string{ts + ".meta", ts + constants.ValidationFileSuffix} {
+		sidecar := sidecar
+		t.Run("sidecar only: "+sidecar, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, sidecar), nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			f, err := existingAudioFile(dir, ts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if f != "" {
+				t.Errorf("sidecar %q must not count as audio; got %q", sidecar, f)
+			}
+		})
+	}
+
+	// Every supported audio extension must be recognised.
+	for _, ext := range []string{".mp3", ".aac", ".ogg", ".opus", ".flac", ".m4a", ".wav"} {
+		ext := ext
+		t.Run("audio file: "+ext, func(t *testing.T) {
+			dir := t.TempDir()
+			want := ts + ext
+			if err := os.WriteFile(filepath.Join(dir, want), nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			f, err := existingAudioFile(dir, ts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if f != want {
+				t.Errorf("got %q, want %q", f, want)
+			}
+		})
+	}
+
+	t.Run("different timestamp audio ignored", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "2026-04-28-11.mp3"), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		f, err := existingAudioFile(dir, ts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if f != "" {
+			t.Errorf("different-timestamp file should not match; got %q", f)
+		}
+	})
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -114,8 +114,9 @@ func (s *Scheduler) startCatchupRecordings() {
 			dir := filepath.Join(s.config.RecordingsDir, stationName)
 			entries, err := os.ReadDir(dir)
 			if err != nil && !os.IsNotExist(err) {
-				slog.Warn("failed to check for existing recording, proceeding with catchup",
+				slog.Error("failed to check for existing recordings, skipping catchup",
 					"station", stationName, "dir", dir, "error", err)
+				return
 			}
 			for _, e := range entries {
 				if !e.IsDir() && strings.HasPrefix(e.Name(), timestamp+".") && utils.IsAudioFile(e.Name()) {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"time"
 
 	"github.com/oszuidwest/zwfm-audiologger/internal/config"
@@ -90,6 +91,11 @@ func (s *Scheduler) startCatchupRecordings() {
 
 	remainingSecs := 3600 - elapsedSecs
 
+	// Skip if too little of the hour remains; a tiny recording is not worth the overhead.
+	if remainingSecs < constants.CatchupMinRemainingSecs {
+		return
+	}
+
 	// Build the timestamp for the start of the current hour in the configured timezone.
 	hourStart := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), 0, 0, 0, now.Location())
 	timestamp := hourStart.Format(utils.HourlyTimestampFormat)
@@ -103,7 +109,7 @@ func (s *Scheduler) startCatchupRecordings() {
 		go func(stationName string, stationCfg *config.Station) {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Error("panic in catchup recording", "station", stationName, "panic", r)
+					slog.Error("panic in catchup recording", "station", stationName, "panic", r, "stack", string(debug.Stack()))
 				}
 			}()
 
@@ -127,7 +133,7 @@ func (s *Scheduler) runAllRecordings() {
 		go func(stationName string, stationConfig *config.Station) {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Error("panic in recording", "station", stationName, "panic", r)
+					slog.Error("panic in recording", "station", stationName, "panic", r, "stack", string(debug.Stack()))
 				}
 			}()
 			s.recorder.Scheduled(stationName, stationConfig)
@@ -139,7 +145,7 @@ func (s *Scheduler) runAllRecordings() {
 func (s *Scheduler) runCleanup() {
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("panic in cleanup", "panic", r)
+			slog.Error("panic in cleanup", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 	s.cleanupOldRecordings()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -7,8 +7,10 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/oszuidwest/zwfm-audiologger/internal/config"
+	"github.com/oszuidwest/zwfm-audiologger/internal/constants"
 	"github.com/oszuidwest/zwfm-audiologger/internal/recorder"
 	"github.com/oszuidwest/zwfm-audiologger/internal/utils"
 	cron "github.com/pardnchiu/go-cron"
@@ -56,6 +58,10 @@ func (s *Scheduler) Start(ctx context.Context) error {
 	}
 	slog.Info("Scheduled daily cleanup", "time", "midnight", "timezone", utils.AppTimezone)
 
+	// If we started mid-hour, immediately record the remaining portion so no
+	// broadcast is lost between startup and the first cron trigger at minute 0.
+	s.startCatchupRecordings()
+
 	// Start the scheduler
 	scheduler.Start()
 	slog.Info("Scheduler started. Press Ctrl+C to stop")
@@ -68,6 +74,51 @@ func (s *Scheduler) Start(ctx context.Context) error {
 	slog.Info("Scheduler stopped")
 
 	return nil
+}
+
+// startCatchupRecordings immediately records the remainder of the current hour
+// if the service started mid-hour. This closes the gap that would otherwise
+// exist between startup and the first cron trigger at minute 0.
+func (s *Scheduler) startCatchupRecordings() {
+	now := utils.Now()
+	elapsedSecs := now.Minute()*60 + now.Second()
+
+	// Skip if we're at (or very near) the start of an hour; the cron handles it.
+	if elapsedSecs < constants.CatchupGraceSecs {
+		return
+	}
+
+	remainingSecs := 3600 - elapsedSecs
+
+	// Build the timestamp for the start of the current hour in the configured timezone.
+	hourStart := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), 0, 0, 0, now.Location())
+	timestamp := hourStart.Format(utils.HourlyTimestampFormat)
+
+	slog.Info("Starting catchup recordings for partial hour",
+		"timestamp", timestamp,
+		"elapsed_secs", elapsedSecs,
+		"remaining_secs", remainingSecs)
+
+	for name, station := range s.config.Stations {
+		go func(stationName string, stationCfg *config.Station) {
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("panic in catchup recording", "station", stationName, "panic", r)
+				}
+			}()
+
+			// Skip if a recording for this hour already exists (e.g. previous run captured it).
+			dir := filepath.Join(s.config.RecordingsDir, stationName)
+			matches, _ := filepath.Glob(filepath.Join(dir, timestamp+".*"))
+			if len(matches) > 0 {
+				slog.Info("Catchup skipped, recording already exists",
+					"station", stationName, "timestamp", timestamp)
+				return
+			}
+
+			s.recorder.Catchup(stationName, stationCfg, timestamp, remainingSecs)
+		}(name, &station)
+	}
 }
 
 // runAllRecordings records all configured stations.
@@ -108,12 +159,18 @@ func (s *Scheduler) cleanupOldRecordings() {
 		}
 
 		for _, file := range files {
-			if info, err := file.Info(); err == nil {
-				if info.ModTime().Before(cutoff) {
-					path := filepath.Join(dir, file.Name())
-					if err := os.Remove(path); err == nil {
-						slog.Info("Deleted old recording", "path", path)
-					}
+			info, err := file.Info()
+			if err != nil {
+				slog.Warn("failed to stat file during cleanup", "file", file.Name(), "error", err)
+				continue
+			}
+
+			if info.ModTime().Before(cutoff) {
+				path := filepath.Join(dir, file.Name())
+				if err := os.Remove(path); err != nil {
+					slog.Error("failed to delete old recording", "path", path, "error", err)
+				} else {
+					slog.Info("Deleted old recording", "path", path)
 				}
 			}
 		}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/oszuidwest/zwfm-audiologger/internal/config"
@@ -83,12 +84,6 @@ func (s *Scheduler) Start(ctx context.Context) error {
 func (s *Scheduler) startCatchupRecordings() {
 	now := utils.Now()
 	elapsedSecs := now.Minute()*60 + now.Second()
-
-	// Skip if we're at (or very near) the start of an hour; the cron handles it.
-	if elapsedSecs < constants.CatchupGraceSecs {
-		return
-	}
-
 	remainingSecs := 3600 - elapsedSecs
 
 	// Skip if too little of the hour remains; a tiny recording is not worth the overhead.
@@ -113,13 +108,21 @@ func (s *Scheduler) startCatchupRecordings() {
 				}
 			}()
 
-			// Skip if a recording for this hour already exists (e.g. previous run captured it).
+			// Skip if an audio file for this hour already exists (e.g. previous run captured it).
+			// Use ReadDir + IsAudioFile rather than a glob so that side-car files
+			// (.meta, .validation.json) do not falsely suppress the catchup.
 			dir := filepath.Join(s.config.RecordingsDir, stationName)
-			matches, _ := filepath.Glob(filepath.Join(dir, timestamp+".*"))
-			if len(matches) > 0 {
-				slog.Info("Catchup skipped, recording already exists",
-					"station", stationName, "timestamp", timestamp)
-				return
+			entries, err := os.ReadDir(dir)
+			if err != nil && !os.IsNotExist(err) {
+				slog.Warn("failed to check for existing recording, proceeding with catchup",
+					"station", stationName, "dir", dir, "error", err)
+			}
+			for _, e := range entries {
+				if !e.IsDir() && strings.HasPrefix(e.Name(), timestamp+".") && utils.IsAudioFile(e.Name()) {
+					slog.Info("Catchup skipped, recording already exists",
+						"station", stationName, "timestamp", timestamp)
+					return
+				}
 			}
 
 			s.recorder.Catchup(stationName, stationCfg, timestamp, remainingSecs)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -78,16 +78,41 @@ func (s *Scheduler) Start(ctx context.Context) error {
 	return nil
 }
 
+// catchupRemaining returns the number of seconds remaining in the current hour
+// and whether that is enough to warrant starting a catchup recording.
+func catchupRemaining(now time.Time) (remainingSecs int, needed bool) {
+	elapsed := now.Minute()*60 + now.Second()
+	remaining := 3600 - elapsed
+	return remaining, remaining >= constants.CatchupMinRemainingSecs
+}
+
+// existingAudioFile returns the filename of the first audio file in dir whose
+// name starts with timestamp+".". Returns an empty string if none is found.
+// Returns an error if the directory cannot be read, except when it does not
+// exist yet (in which case an empty string and nil error are returned).
+func existingAudioFile(dir, timestamp string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), timestamp+".") && utils.IsAudioFile(e.Name()) {
+			return e.Name(), nil
+		}
+	}
+	return "", nil
+}
+
 // startCatchupRecordings immediately records the remainder of the current hour
 // if the service started mid-hour. This closes the gap that would otherwise
 // exist between startup and the first cron trigger at minute 0.
 func (s *Scheduler) startCatchupRecordings() {
 	now := utils.Now()
-	elapsedSecs := now.Minute()*60 + now.Second()
-	remainingSecs := 3600 - elapsedSecs
-
-	// Skip if too little of the hour remains; a tiny recording is not worth the overhead.
-	if remainingSecs < constants.CatchupMinRemainingSecs {
+	remainingSecs, needed := catchupRemaining(now)
+	if !needed {
 		return
 	}
 
@@ -97,7 +122,7 @@ func (s *Scheduler) startCatchupRecordings() {
 
 	slog.Info("Starting catchup recordings for partial hour",
 		"timestamp", timestamp,
-		"elapsed_secs", elapsedSecs,
+		"elapsed_secs", 3600-remainingSecs,
 		"remaining_secs", remainingSecs)
 
 	for name, station := range s.config.Stations {
@@ -108,22 +133,17 @@ func (s *Scheduler) startCatchupRecordings() {
 				}
 			}()
 
-			// Skip if an audio file for this hour already exists (e.g. previous run captured it).
-			// Use ReadDir + IsAudioFile rather than a glob so that side-car files
-			// (.meta, .validation.json) do not falsely suppress the catchup.
 			dir := filepath.Join(s.config.RecordingsDir, stationName)
-			entries, err := os.ReadDir(dir)
-			if err != nil && !os.IsNotExist(err) {
+			existing, err := existingAudioFile(dir, timestamp)
+			if err != nil {
 				slog.Error("failed to check for existing recordings, skipping catchup",
 					"station", stationName, "dir", dir, "error", err)
 				return
 			}
-			for _, e := range entries {
-				if !e.IsDir() && strings.HasPrefix(e.Name(), timestamp+".") && utils.IsAudioFile(e.Name()) {
-					slog.Info("Catchup skipped, recording already exists",
-						"station", stationName, "timestamp", timestamp)
-					return
-				}
+			if existing != "" {
+				slog.Info("Catchup skipped, recording already exists",
+					"station", stationName, "file", existing)
+				return
 			}
 
 			s.recorder.Catchup(stationName, stationCfg, timestamp, remainingSecs)

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/oszuidwest/zwfm-audiologger/internal/constants"
 )
@@ -40,4 +41,15 @@ func IsAudioFile(name string) bool {
 	default:
 		return false
 	}
+}
+
+// AvailableDiskBytes returns the number of free bytes available on the filesystem
+// containing the given path.
+func AvailableDiskBytes(path string) (uint64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, fmt.Errorf("statfs %s: %w", path, err)
+	}
+	//nolint:gosec // Bsize is always positive; conversion from signed to unsigned is safe here.
+	return stat.Bavail * uint64(stat.Bsize), nil
 }

--- a/internal/validator/alerter.go
+++ b/internal/validator/alerter.go
@@ -222,7 +222,7 @@ func buildEmailContent(result *ValidationResult) string {
 	if len(result.Issues) > 0 {
 		b.WriteString("<h3>Issues:</h3><ul>")
 		for _, issue := range result.Issues {
-			fmt.Fprintf(&b, "<li>%s</li>", issue)
+			fmt.Fprintf(&b, "<li>%s</li>", html.EscapeString(issue))
 		}
 		b.WriteString("</ul>")
 	}

--- a/internal/validator/alerter.go
+++ b/internal/validator/alerter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"log/slog"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/oszuidwest/zwfm-audiologger/internal/config"
 	"github.com/oszuidwest/zwfm-audiologger/internal/constants"
+	"github.com/oszuidwest/zwfm-audiologger/internal/utils"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -141,7 +143,7 @@ func buildRecordingFailureContent(station, reason string) string {
 	b.WriteString("<h2>Recording Failed</h2>")
 	b.WriteString("<table style='border-collapse: collapse;'>")
 	writeTableRow(&b, "Station", station)
-	writeTableRow(&b, "Time", time.Now().Format(time.RFC3339))
+	writeTableRow(&b, "Time", utils.Now().Format(time.RFC3339))
 	writeTableRow(&b, "Reason", reason)
 	b.WriteString("</table>")
 	b.WriteString("</body></html>")
@@ -231,9 +233,9 @@ func buildEmailContent(result *ValidationResult) string {
 	return b.String()
 }
 
-// writeTableRow writes an HTML table row to the builder.
+// writeTableRow writes an HTML table row to the builder, escaping the value.
 func writeTableRow(b *strings.Builder, label, value string) {
-	fmt.Fprintf(b, "<tr><td><strong>%s:</strong></td><td>%s</td></tr>", label, value)
+	fmt.Fprintf(b, "<tr><td><strong>%s:</strong></td><td>%s</td></tr>", label, html.EscapeString(value))
 }
 
 // buildRecipientList converts email addresses to Graph API recipient format.

--- a/internal/validator/alerter.go
+++ b/internal/validator/alerter.go
@@ -108,6 +108,47 @@ func (a *Alerter) Send(ctx context.Context, result *ValidationResult) error {
 	return a.sendWithRetry(ctx, message)
 }
 
+// SendRecordingFailure sends an alert email when a recording fails to be created.
+func (a *Alerter) SendRecordingFailure(ctx context.Context, station, reason string) error {
+	recipients := a.getRecipients(station)
+	if len(recipients) == 0 {
+		slog.Warn("no alert recipients configured", "station", station)
+		return nil
+	}
+
+	subject := fmt.Sprintf("%s Recording failed: %s", emailSubjectPrefix, station)
+	content := buildRecordingFailureContent(station, reason)
+
+	message := &graphMailRequest{
+		Message: graphMessage{
+			Subject: subject,
+			Body: graphBody{
+				ContentType: emailContentType,
+				Content:     content,
+			},
+			ToRecipients: buildRecipientList(recipients),
+		},
+	}
+
+	return a.sendWithRetry(ctx, message)
+}
+
+// buildRecordingFailureContent constructs an HTML email body for a recording failure.
+func buildRecordingFailureContent(station, reason string) string {
+	var b strings.Builder
+
+	b.WriteString("<html><body>")
+	b.WriteString("<h2>Recording Failed</h2>")
+	b.WriteString("<table style='border-collapse: collapse;'>")
+	writeTableRow(&b, "Station", station)
+	writeTableRow(&b, "Time", time.Now().Format(time.RFC3339))
+	writeTableRow(&b, "Reason", reason)
+	b.WriteString("</table>")
+	b.WriteString("</body></html>")
+
+	return b.String()
+}
+
 // getRecipients returns the email recipients for a station.
 func (a *Alerter) getRecipients(station string) []string {
 	// Check station-specific recipients first.

--- a/internal/validator/result.go
+++ b/internal/validator/result.go
@@ -18,6 +18,7 @@ type ValidationResult struct {
 	SilencePercent float64   `json:"silence_percent"`
 	LoopPercent    float64   `json:"loop_percent"`
 	Valid          bool      `json:"valid"`
+	Skipped        bool      `json:"skipped,omitempty"`
 	Issues         []string  `json:"issues,omitempty"`
 }
 

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -81,7 +81,9 @@ func (m *Manager) NotifyRecordingFailure(station, reason string) {
 	if m.alerter == nil {
 		return
 	}
-	if err := m.alerter.SendRecordingFailure(context.Background(), station, reason); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), constants.AlertNotifyTimeout)
+	defer cancel()
+	if err := m.alerter.SendRecordingFailure(ctx, station, reason); err != nil {
 		slog.Error("failed to send recording failure alert", "station", station, "error", err)
 	}
 }

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -97,6 +97,7 @@ func (m *Manager) MarkSkipped(filePath, station, timestamp string) {
 		Timestamp:   timestamp,
 		ValidatedAt: utils.Now(),
 		Valid:        true,
+		Skipped:     true,
 	}
 	validationFile := utils.SidecarPath(filePath, constants.ValidationFileSuffix)
 	if err := result.Save(validationFile); err != nil {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -96,7 +96,7 @@ func (m *Manager) MarkSkipped(filePath, station, timestamp string) {
 		Station:     station,
 		Timestamp:   timestamp,
 		ValidatedAt: utils.Now(),
-		Valid:        true,
+		Valid:       true,
 		Skipped:     true,
 	}
 	validationFile := utils.SidecarPath(filePath, constants.ValidationFileSuffix)

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -88,6 +88,22 @@ func (m *Manager) NotifyRecordingFailure(station, reason string) {
 	}
 }
 
+// MarkSkipped writes a validation sidecar that marks a recording as valid without
+// running validation checks. This prevents scanUnvalidated from re-queuing the
+// file on the next startup after a catchup recording.
+func (m *Manager) MarkSkipped(filePath, station, timestamp string) {
+	result := &ValidationResult{
+		Station:     station,
+		Timestamp:   timestamp,
+		ValidatedAt: utils.Now(),
+		Valid:        true,
+	}
+	validationFile := utils.SidecarPath(filePath, constants.ValidationFileSuffix)
+	if err := result.Save(validationFile); err != nil {
+		slog.Error("failed to write catchup validation sidecar", "file", validationFile, "error", err)
+	}
+}
+
 // Enqueue adds a file to the validation queue (non-blocking).
 func (m *Manager) Enqueue(filePath, station, timestamp string) {
 	job := ValidationJob{

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -75,6 +75,17 @@ func (m *Manager) Stop() {
 	m.cancel()
 }
 
+// NotifyRecordingFailure sends an alert when a recording fails to be created.
+// This is called by the recorder when FFmpeg or remux fails.
+func (m *Manager) NotifyRecordingFailure(station, reason string) {
+	if m.alerter == nil {
+		return
+	}
+	if err := m.alerter.SendRecordingFailure(context.Background(), station, reason); err != nil {
+		slog.Error("failed to send recording failure alert", "station", station, "error", err)
+	}
+}
+
 // Enqueue adds a file to the validation queue (non-blocking).
 func (m *Manager) Enqueue(filePath, station, timestamp string) {
 	job := ValidationJob{

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -1,0 +1,58 @@
+package validator_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oszuidwest/zwfm-audiologger/internal/config"
+	"github.com/oszuidwest/zwfm-audiologger/internal/constants"
+	"github.com/oszuidwest/zwfm-audiologger/internal/utils"
+	"github.com/oszuidwest/zwfm-audiologger/internal/validator"
+)
+
+func TestMarkSkipped(t *testing.T) {
+	dir := t.TempDir()
+	audioPath := filepath.Join(dir, "2026-04-28-12.mp3")
+	if err := os.WriteFile(audioPath, []byte("fake audio"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := validator.New(&config.Config{RecordingsDir: dir})
+	defer m.Stop()
+
+	const station = "teststation"
+	const timestamp = "2026-04-28-12"
+	m.MarkSkipped(audioPath, station, timestamp)
+
+	sidecarPath := utils.SidecarPath(audioPath, constants.ValidationFileSuffix)
+
+	// Sidecar must exist so that scanUnvalidated does not re-queue on restart.
+	data, err := os.ReadFile(sidecarPath) //nolint:gosec // path is constructed from t.TempDir(), not user input
+	if err != nil {
+		t.Fatalf("sidecar not written: %v", err)
+	}
+
+	var result struct {
+		Station   string `json:"station"`
+		Timestamp string `json:"timestamp"`
+		Valid     bool   `json:"valid"`
+		Skipped   bool   `json:"skipped"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("failed to parse sidecar JSON: %v", err)
+	}
+	if !result.Valid {
+		t.Error("sidecar valid should be true")
+	}
+	if !result.Skipped {
+		t.Error("sidecar skipped should be true, to distinguish from a fully validated recording")
+	}
+	if result.Station != station {
+		t.Errorf("sidecar station = %q, want %q", result.Station, station)
+	}
+	if result.Timestamp != timestamp {
+		t.Errorf("sidecar timestamp = %q, want %q", result.Timestamp, timestamp)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -81,8 +81,16 @@ func main() {
 		validatorManager = validator.New(cfg)
 	}
 
+	// Build a non-nil Notifier only when the validator is active; passing a nil
+	// concrete pointer as an interface would produce a non-nil interface value and
+	// cause unexpected behaviour in the recorder.
+	var notifier recorder.Notifier
+	if validatorManager != nil {
+		notifier = validatorManager
+	}
+
 	// Initialize components.
-	recorderManager := recorder.New(cfg, validatorManager)
+	recorderManager := recorder.New(cfg, validatorManager, notifier)
 
 	// Run test mode if requested.
 	if *testMode {


### PR DESCRIPTION
## What

Five reliability gaps that could cause silent recording loss or false alerts, closed in one pass.

## Changes

### 1. Startup catchup recording (`scheduler.go`)
If the service restarts mid-hour (crash, deploy, Docker restart), it immediately starts a partial recording for the remaining seconds of the current hour. Without this, up to 59 minutes of broadcast were silently lost on every restart.

Correctness details:
- `startCatchupRecordings` runs **before** `scheduler.Start()`, so the grace-period skip at the start of the hour was wrong — the cron never fires retroactively. Starting at 12:00:01 now triggers a catchup.
- The existing-file check uses `os.ReadDir` + `IsAudioFile` instead of a glob. A leftover `.meta` or `.validation.json` sidecar from a previous crash no longer falsely suppresses the catchup.
- Catchup recordings skip normal validation (would always fail `MinDurationSecs`). Instead a `.validation.json` sidecar is written immediately with `valid: true, skipped: true`, so `scanUnvalidated` does not re-queue the file on the next startup.
- Catchups shorter than 60 seconds (service started near the end of the hour) are skipped.

### 2. Disk space guard (`recorder.go`, `utils/files.go`, `constants.go`)
Before each recording, free disk space is checked via `syscall.Statfs`. Below 1 GB the recording is skipped and a failure alert is sent. The check is **fail-closed**: a `statfs` error now errors, notifies, and returns rather than logging a warning and proceeding.

### 3. Recording failure alerts (`recorder.go`, `validator/alerter.go`, `validator/validator.go`, `main.go`)
The MS Graph alerter is wired to the recorder via a `Notifier` interface. FFmpeg failures, remux failures, and disk-guard failures all trigger an immediate email alert. Previously these were log-only.

Additional improvements:
- Alert delivery uses a `context.WithTimeout` (2 min) so a slow mail server cannot block a recording goroutine indefinitely.
- `writeTableRow` and validation issue list items are HTML-escaped.
- Alert timestamps use `utils.Now()` for timezone consistency.

### 4. Cleanup error logging (`scheduler.go`)
`os.Remove` failures during daily cleanup were silently swallowed. They now log as `ERROR`.

### 5. Windows dropped from release matrix (`.github/workflows/release.yml`)
`syscall.Statfs` (disk guard) and `go-cron`'s `log/syslog` dependency both fail to compile on Windows. Windows is not a supported deployment target for this service.

### 6. Audit field on skipped validation (`validator/result.go`)
`ValidationResult` gains a `Skipped bool \`json:"skipped,omitempty"\`` field. Catchup sidecars carry `skipped: true` so future reporting can distinguish them from genuinely validated recordings.

### 7. Panic recovery includes stack traces (`scheduler.go`)
All three `recover()` handlers now log `debug.Stack()`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run`
- [x] `go test ./...`
- [x] `TestCatchupRemaining` — 60 s minimum-remaining boundary, start-of-hour, near-end-of-hour
- [x] `TestExistingAudioFile` — all 7 audio extensions recognised; `.meta` and `.validation.json` sidecars do not suppress catchup; non-existent dir handled gracefully; different-timestamp files ignored
- [x] `TestMarkSkipped` — sidecar written with `valid: true`, `skipped: true`, correct station and timestamp
- [x] Cross-compile: `linux/amd64`, `linux/arm64`, `darwin/arm64`
- [x] Start service mid-hour, verify catchup recording appears with correct hour-start filename — confirmed `"Starting catchup recordings for partial hour","timestamp":"2026-04-28-22","elapsed_secs":1056`
- [x] Start service when recording for current hour already exists, verify catchup is skipped — confirmed `"Catchup skipped, recording already exists"` for both stations
- [x] Start service when only a `.meta` sidecar exists for the current hour, verify catchup is NOT skipped — confirmed catchup fires, `.meta` not mistaken for audio file
- [x] Fill disk to <1 GB, verify recording is skipped — confirmed `"skipping recording","reason":"insufficient disk space: 536870912 bytes available, 1073741824 required"` via tmpfs (512 MB limit)
- [x] Force FFmpeg to fail (bad stream URL), verify failure is logged — confirmed `"msg":"failed recording","error":"exit status 145"` with full ffmpeg command
- [x] Restart service after a catchup; verify the catchup file is not re-queued — confirmed `"Catchup skipped, recording already exists"` on restart with pre-staged audio + sidecar
- [ ] Start service at 12:00:01, verify catchup fires — not easily testable in Docker (requires time manipulation); covered by `TestCatchupRemaining` unit test
- [ ] Force `statfs` to fail, verify recording is skipped and alert is sent — requires root filesystem manipulation; covered by fail-closed logic in code review
- [ ] Alert emails (disk guard, FFmpeg failure) — requires MS Graph credentials; infrastructure-dependent
- [ ] Verify cleanup errors surface in logs — runs at midnight; not testable in this session