### PR TITLE
fix: post-review corrections after rock-solid recording PR

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -60,8 +60,9 @@ const (
 	// MinDiskSpaceBytes is the minimum free disk space required before starting a recording.
 	MinDiskSpaceBytes = uint64(1 * 1024 * 1024 * 1024) // 1 GB
 
-	// CatchupMinRemainingSecs is the minimum seconds remaining in an hour to bother
-	// starting a catchup recording. Below this threshold the overhead is not worth it.
+	// CatchupMinRemainingSecs is the minimum seconds remaining in an hour to start
+	// a catchup recording. Below this threshold the partial file is too short to be
+	// useful and would fail normal duration validation if it is ever re-queued.
 	CatchupMinRemainingSecs = 60
 
 	// AlertNotifyTimeout is the maximum time allowed to deliver a recording failure alert,

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -19,6 +19,7 @@ import (
 
 // Validator defines the interface for recording validation.
 type Validator interface {
+	// Enqueue adds a completed recording to the validation queue.
 	Enqueue(filePath, station, timestamp string)
 	// MarkSkipped writes a validation sidecar that marks a recording as valid
 	// without running validation checks. Used for catchup recordings so that
@@ -79,7 +80,11 @@ func (m *Manager) Catchup(name string, station *config.Station, timestamp string
 func (m *Manager) record(name string, station *config.Station, timestamp, duration string, timeout time.Duration, skipValidation bool) {
 	dir := filepath.Join(m.config.RecordingsDir, name)
 	if err := utils.EnsureDir(dir); err != nil {
-		slog.Error("failed to create directory", "station", name, "error", err, "recordings_dir", m.config.RecordingsDir, "computed_dir", dir)
+		reason := fmt.Sprintf("failed to create recording directory: %v", err)
+		slog.Error("skipping recording", "station", name, "reason", reason, "recordings_dir", m.config.RecordingsDir, "computed_dir", dir)
+		if m.notifier != nil {
+			m.notifier.NotifyRecordingFailure(name, reason)
+		}
 		return
 	}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -184,6 +184,9 @@ func (s *Scheduler) cleanupOldRecordings() {
 		dir := filepath.Join(s.config.RecordingsDir, station)
 		files, err := os.ReadDir(dir)
 		if err != nil {
+			if os.IsNotExist(err) {
+				continue // station has no recordings yet
+			}
 			slog.Error("failed to read directory", "dir", dir, "error", err)
 			continue
 		}

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -43,8 +43,8 @@ func IsAudioFile(name string) bool {
 	}
 }
 
-// AvailableDiskBytes returns the number of free bytes available on the filesystem
-// containing the given path.
+// AvailableDiskBytes returns bytes available to unprivileged users on the
+// filesystem containing the given path.
 func AvailableDiskBytes(path string) (uint64, error) {
 	var stat syscall.Statfs_t
 	if err := syscall.Statfs(path, &stat); err != nil {

--- a/internal/validator/alerter.go
+++ b/internal/validator/alerter.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/oszuidwest/zwfm-audiologger/internal/config"
 	"github.com/oszuidwest/zwfm-audiologger/internal/constants"
-	"github.com/oszuidwest/zwfm-audiologger/internal/utils"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -111,7 +110,7 @@ func (a *Alerter) Send(ctx context.Context, result *ValidationResult) error {
 }
 
 // SendRecordingFailure sends an alert email when a recording fails to be created.
-func (a *Alerter) SendRecordingFailure(ctx context.Context, station, reason string) error {
+func (a *Alerter) SendRecordingFailure(ctx context.Context, station, reason string, failedAt time.Time) error {
 	recipients := a.getRecipients(station)
 	if len(recipients) == 0 {
 		slog.Warn("no alert recipients configured", "station", station)
@@ -119,7 +118,7 @@ func (a *Alerter) SendRecordingFailure(ctx context.Context, station, reason stri
 	}
 
 	subject := fmt.Sprintf("%s Recording failed: %s", emailSubjectPrefix, station)
-	content := buildRecordingFailureContent(station, reason)
+	content := buildRecordingFailureContent(station, reason, failedAt)
 
 	message := &graphMailRequest{
 		Message: graphMessage{
@@ -136,14 +135,14 @@ func (a *Alerter) SendRecordingFailure(ctx context.Context, station, reason stri
 }
 
 // buildRecordingFailureContent constructs an HTML email body for a recording failure.
-func buildRecordingFailureContent(station, reason string) string {
+func buildRecordingFailureContent(station, reason string, failedAt time.Time) string {
 	var b strings.Builder
 
 	b.WriteString("<html><body>")
 	b.WriteString("<h2>Recording Failed</h2>")
 	b.WriteString("<table style='border-collapse: collapse;'>")
 	writeTableRow(&b, "Station", station)
-	writeTableRow(&b, "Time", utils.Now().Format(time.RFC3339))
+	writeTableRow(&b, "Failed at", failedAt.Format(time.RFC3339))
 	writeTableRow(&b, "Reason", reason)
 	b.WriteString("</table>")
 	b.WriteString("</body></html>")
@@ -233,9 +232,9 @@ func buildEmailContent(result *ValidationResult) string {
 	return b.String()
 }
 
-// writeTableRow writes an HTML table row to the builder, escaping the value.
+// writeTableRow writes an HTML table row to the builder, escaping the label and value.
 func writeTableRow(b *strings.Builder, label, value string) {
-	fmt.Fprintf(b, "<tr><td><strong>%s:</strong></td><td>%s</td></tr>", label, html.EscapeString(value))
+	fmt.Fprintf(b, "<tr><td><strong>%s:</strong></td><td>%s</td></tr>", html.EscapeString(label), html.EscapeString(value))
 }
 
 // buildRecipientList converts email addresses to Graph API recipient format.
@@ -290,8 +289,12 @@ func (a *Alerter) sendWithRetry(ctx context.Context, message *graphMailRequest) 
 			continue
 		}
 
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, readErr := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
+		respText := string(respBody)
+		if readErr != nil {
+			respText = fmt.Sprintf("failed to read response body: %v", readErr)
+		}
 
 		switch resp.StatusCode {
 		case http.StatusAccepted, http.StatusOK, http.StatusNoContent:
@@ -304,16 +307,16 @@ func (a *Alerter) sendWithRetry(ctx context.Context, message *graphMailRequest) 
 					retryWait = time.Duration(seconds) * time.Second
 				}
 			}
-			lastErr = fmt.Errorf("rate limited (429): %s", string(respBody))
+			lastErr = fmt.Errorf("rate limited (429): %s", respText)
 			continue
 		case http.StatusInternalServerError, http.StatusBadGateway,
 			http.StatusServiceUnavailable, http.StatusGatewayTimeout:
 			// Transient server errors - retry.
-			lastErr = fmt.Errorf("server error %d: %s", resp.StatusCode, string(respBody))
+			lastErr = fmt.Errorf("server error %d: %s", resp.StatusCode, respText)
 			continue
 		default:
 			// Non-retryable error.
-			return fmt.Errorf("graph API error %d: %s", resp.StatusCode, string(respBody))
+			return fmt.Errorf("graph API error %d: %s", resp.StatusCode, respText)
 		}
 	}
 

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -76,14 +76,16 @@ func (m *Manager) Stop() {
 }
 
 // NotifyRecordingFailure sends an alert when a recording fails to be created.
-// This is called by the recorder when FFmpeg or remux fails.
+// Called by the recorder for any recording failure: directory creation error,
+// insufficient disk space, disk check error, FFmpeg failure, or remux failure.
 func (m *Manager) NotifyRecordingFailure(station, reason string) {
 	if m.alerter == nil {
 		return
 	}
+	failedAt := utils.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), constants.AlertNotifyTimeout)
 	defer cancel()
-	if err := m.alerter.SendRecordingFailure(ctx, station, reason); err != nil {
+	if err := m.alerter.SendRecordingFailure(ctx, station, reason, failedAt); err != nil {
 		slog.Error("failed to send recording failure alert", "station", station, "error", err)
 	}
 }
@@ -101,7 +103,8 @@ func (m *Manager) MarkSkipped(filePath, station, timestamp string) {
 	}
 	validationFile := utils.SidecarPath(filePath, constants.ValidationFileSuffix)
 	if err := result.Save(validationFile); err != nil {
-		slog.Error("failed to write catchup validation sidecar", "file", validationFile, "error", err)
+		slog.Error("failed to write catchup validation sidecar; file may be re-queued for validation on next startup and may trigger a false short-duration failure alert",
+			"file", validationFile, "error", err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -81,16 +81,19 @@ func main() {
 		validatorManager = validator.New(cfg)
 	}
 
-	// Build a non-nil Notifier only when the validator is active; passing a nil
-	// concrete pointer as an interface would produce a non-nil interface value and
-	// cause unexpected behaviour in the recorder.
+	// Build non-nil interface values only when the validator is active. Passing a
+	// typed nil concrete pointer as an interface produces a non-nil interface value
+	// (the type field is set, the value field is nil), which bypasses nil guards in
+	// the recorder and causes a nil-pointer panic on first use.
+	var validatorIface recorder.Validator
 	var notifier recorder.Notifier
 	if validatorManager != nil {
+		validatorIface = validatorManager
 		notifier = validatorManager
 	}
 
 	// Initialize components.
-	recorderManager := recorder.New(cfg, validatorManager, notifier)
+	recorderManager := recorder.New(cfg, validatorIface, notifier)
 
 	// Run test mode if requested.
 	if *testMode {


### PR DESCRIPTION
## What

Follow-up to #34 -- corrections found during code review that were applied locally but not committed before merge.

## Changes

### Bug fix (blocker)
- **Nil `Validator` interface panic** (`main.go`): `validatorManager` was passed directly as `recorder.Validator`, producing a non-nil interface value with a nil underlying pointer. This bypassed the `m.validator != nil` guard in the recorder and caused a nil-pointer panic on `Enqueue` -- i.e. on every recording when validation is disabled. Now guarded identically to `Notifier`.

### Reliability
- **`EnsureDir` failure now notifies** (`recorder.go`): directory creation errors trigger `NotifyRecordingFailure`, consistent with all other failure paths (disk, FFmpeg, remux).
- **`cleanupOldRecordings` skips missing directories** (`scheduler.go`): a missing station directory (station never recorded yet) previously logged a spurious `ERROR` on every midnight cleanup run. Now silently skipped with `os.IsNotExist`.

### Correctness
- **`failedAt` timestamp** (`validator.go`, `alerter.go`): the failure time is now captured at the moment of failure and passed through to the email, rather than being set at alert-delivery time.
- **`writeTableRow` escapes label and value** (`alerter.go`): previously only `value` was HTML-escaped; `label` is now also escaped for consistency.
- **`io.ReadAll` error handled** (`alerter.go`): partial-read bodies now produce a descriptive error string in retry logs instead of a silent empty body.

### Documentation
- `AvailableDiskBytes`: "free bytes" changed to "bytes available to unprivileged users" (reflects `Bavail` vs `Bfree`)
- `CatchupMinRemainingSecs`: "overhead is not worth it" updated to explain the real reason (file too short, would fail duration validation)
- `NotifyRecordingFailure`: lists all four call sites, not just FFmpeg/remux
- `Enqueue`: added doc comment to match `MarkSkipped` in the `Validator` interface
- `writeTableRow`: updated doc to mention label escaping

## Test plan
- [ ] `go build ./...`
- [ ] `go test ./...`
- [ ] `go vet ./...`