### PR TITLE
refactor: switch from pardnchiu/go-cron to netresearch/go-cron

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/dustin/go-humanize v1.0.1
-	github.com/pardnchiu/go-cron v1.1.0
+	github.com/netresearch/go-cron v0.14.0
 )
 
 require golang.org/x/oauth2 v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,6 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/pardnchiu/go-cron v1.1.0 h1:ueHtqRrrIDn03U5Rs3VmD+sNzz4aRy8vFRdy4Y6POHo=
-github.com/pardnchiu/go-cron v1.1.0/go.mod h1:nEUX+uJ63wal1RVCskneyZcwZP2ty2cHMisH2GL8NYI=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/netresearch/go-cron v0.14.0 h1:CnUt6kGjet0dQL6rc4xmS+q2EbP9BKR9kh4AX5bnc5U=
+github.com/netresearch/go-cron v0.14.0/go.mod h1:79iktHfV90py3jcaFUtWcGSKbZXRev+WwoLMyV5eMvo=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -32,7 +32,7 @@ func New(cfg *config.Config, rec *recorder.Manager) *Scheduler {
 	}
 }
 
-// Start begins the scheduling using pardnchiu/go-cron.
+// Start begins the scheduling using netresearch/go-cron.
 func (s *Scheduler) Start(ctx context.Context) error {
 	// Create scheduler using the global timezone (already set in main)
 	scheduler := cron.New(cron.WithLocation(utils.AppTimezone))

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 	"time"
 
+	cron "github.com/netresearch/go-cron"
 	"github.com/oszuidwest/zwfm-audiologger/internal/config"
 	"github.com/oszuidwest/zwfm-audiologger/internal/constants"
 	"github.com/oszuidwest/zwfm-audiologger/internal/recorder"
 	"github.com/oszuidwest/zwfm-audiologger/internal/utils"
-	cron "github.com/pardnchiu/go-cron"
 )
 
 // Scheduler manages scheduled recordings and cleanup tasks.
@@ -35,21 +35,16 @@ func New(cfg *config.Config, rec *recorder.Manager) *Scheduler {
 // Start begins the scheduling using pardnchiu/go-cron.
 func (s *Scheduler) Start(ctx context.Context) error {
 	// Create scheduler using the global timezone (already set in main)
-	scheduler, err := cron.New(cron.Config{
-		Location: utils.AppTimezone,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create scheduler: %w", err)
-	}
+	scheduler := cron.New(cron.WithLocation(utils.AppTimezone))
 
 	// Schedule hourly recordings at minute 0 of every hour
-	_, err = scheduler.Add("0 * * * *", s.runAllRecordings, "Hourly recordings")
+	_, err := scheduler.AddFunc("0 * * * *", s.runAllRecordings, cron.WithName("Hourly recordings"))
 	if err != nil {
 		return fmt.Errorf("failed to schedule hourly recordings: %w", err)
 	}
 
 	// Schedule daily cleanup at midnight
-	_, err = scheduler.Add("0 0 * * *", s.runCleanup, "Daily cleanup")
+	_, err = scheduler.AddFunc("0 0 * * *", s.runCleanup, cron.WithName("Daily cleanup"))
 	if err != nil {
 		return fmt.Errorf("failed to schedule daily cleanup: %w", err)
 	}


### PR DESCRIPTION
Replace the cron scheduling library with the actively maintained netresearch fork (drop-in replacement for robfig/cron).

## Changes
- Update go.mod dependency from `github.com/pardnchiu/go-cron` to `github.com/netresearch/go-cron` v0.14.0
- Migrate scheduler.go to new API:
  - `cron.New(cron.Config{Location})` → `cron.New(cron.WithLocation)`
  - `scheduler.Add(spec, fn, name)` → `scheduler.AddFunc(spec, fn, cron.WithName)`
  - `cron.New` no longer returns an error

## Behavior verification
- Hourly recordings at minute 0: `0 * * * *`
- Daily cleanup at midnight: `0 0 * * *`
- Timezone handling preserved via `WithLocation`
- Build passes

Closes #35