### PR TITLE
modernize: use slices.SortFunc instead of sort.Slice

### DIFF
--- a/internal/server/files.go
+++ b/internal/server/files.go
@@ -1,13 +1,14 @@
 package server
 
 import (
+	"cmp"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -123,11 +124,14 @@ func (s *Server) showDirectoryListing(w http.ResponseWriter, _ *http.Request, fs
 	}
 
 	// Sort files (directories first, then by name)
-	sort.Slice(files, func(i, j int) bool {
-		if files[i].IsDir != files[j].IsDir {
-			return files[i].IsDir
+	slices.SortFunc(files, func(a, b FileInfo) int {
+		if a.IsDir != b.IsDir {
+			if a.IsDir {
+				return -1
+			}
+			return 1
 		}
-		return files[i].Name < files[j].Name
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	// Render directory listing using template


### PR DESCRIPTION
## Summary

- Replaces `sort.Slice` with `slices.SortFunc` in `internal/server/files.go` (around line 126)
- Swaps `"sort"` import for `"slices"` and `"cmp"` (both standard library, available since Go 1.21)
- Comparator now returns `int` instead of `bool`, using `cmp.Compare` for name comparison and explicit `-1`/`1` returns for the directory-first ordering

## Details

`slices.SortFunc` is the modern, type-safe alternative to `sort.Slice`:
- Works directly on typed values (`FileInfo`) instead of index-based access
- Comparator signature `func(a, b T) int` is consistent with `cmp.Compare` and `strings.Compare`
- No accidental index-out-of-bounds bugs possible

## Note on t.Context()

The repo's two test files (`internal/scheduler/catchup_test.go`, `internal/validator/validator_test.go`) do not call `context.Background()`, so no test-file changes were needed.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go test ./...` passes
- [ ] Directory listing in the web UI still sorts directories before files and alphabetically within each group