### PR TITLE
fix: error handling and naming convention violations

### DIFF
--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -132,7 +133,7 @@ func (m *Manager) record(name string, station *config.Station, timestamp, durati
 		slog.Error("failed recording", "station", name, "error", err, "ffmpeg_command", strings.Join(cmd.Args[1:], " "), "stream_url", station.StreamURL, "output_file", tempFile, "ffmpeg_output", outputStr)
 
 		if m.notifier != nil {
-			m.notifier.NotifyRecordingFailure(name, fmt.Sprintf("FFmpeg failed: %v", err))
+			m.notifier.NotifyRecordingFailure(name, fmt.Sprintf("ffmpeg failed: %v", err))
 		}
 
 		// Clean up temp file if it was created
@@ -188,6 +189,12 @@ func (m *Manager) record(name string, station *config.Station, timestamp, durati
 
 // saveMetadata fetches and saves metadata for a recording.
 func (m *Manager) saveMetadata(stationName string, station *config.Station, timestamp string) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("panic in saveMetadata", "station", stationName, "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
+
 	meta := m.metadataFetcher.Fetch(
 		station.MetadataURL,
 		station.MetadataPath,

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -191,7 +191,7 @@ func (m *Manager) record(name string, station *config.Station, timestamp, durati
 func (m *Manager) saveMetadata(stationName string, station *config.Station, timestamp string) {
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("panic in saveMetadata", "station", stationName, "panic", r, "stack", string(debug.Stack()))
+			slog.Error("panic in saveMetadata; metadata sidecar was not written for this recording", "station", stationName, "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -191,7 +191,8 @@ func (m *Manager) record(name string, station *config.Station, timestamp, durati
 func (m *Manager) saveMetadata(stationName string, station *config.Station, timestamp string) {
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("panic in saveMetadata; metadata sidecar was not written for this recording", "station", stationName, "panic", r, "stack", string(debug.Stack()))
+			slog.Error("panic in saveMetadata; metadata sidecar was not written for this recording",
+				"station", stationName, "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -21,7 +21,8 @@ var (
 )
 
 // SetTimezone sets the application timezone from a timezone string.
-func SetTimezone(timezoneStr string) error {
+// Falls back to UTC and logs a warning if the timezone string is invalid.
+func SetTimezone(timezoneStr string) {
 	loc, err := time.LoadLocation(timezoneStr)
 	if err != nil {
 		slog.Warn("failed to load timezone, using UTC", "timezone", timezoneStr, "error", err)
@@ -33,8 +34,6 @@ func SetTimezone(timezoneStr string) error {
 	timezoneMutex.Lock()
 	AppTimezone = loc
 	timezoneMutex.Unlock()
-
-	return err
 }
 
 // Now returns the current time in the configured timezone.

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -25,7 +25,8 @@ var (
 func SetTimezone(timezoneStr string) {
 	loc, err := time.LoadLocation(timezoneStr)
 	if err != nil {
-		slog.Error("invalid timezone in config, falling back to UTC; recording filenames will use UTC timestamps", "timezone", timezoneStr, "error", err)
+		slog.Error("invalid timezone in config, falling back to UTC; recording filenames will use UTC timestamps",
+			"timezone", timezoneStr, "error", err)
 		loc = time.UTC
 	} else {
 		slog.Info("Timezone set", "timezone", timezoneStr)

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -21,11 +21,11 @@ var (
 )
 
 // SetTimezone sets the application timezone from a timezone string.
-// Falls back to UTC and logs a warning if the timezone string is invalid.
+// Falls back to UTC and logs an error if the timezone string is invalid.
 func SetTimezone(timezoneStr string) {
 	loc, err := time.LoadLocation(timezoneStr)
 	if err != nil {
-		slog.Warn("failed to load timezone, using UTC", "timezone", timezoneStr, "error", err)
+		slog.Error("invalid timezone in config, falling back to UTC; recording filenames will use UTC timestamps", "timezone", timezoneStr, "error", err)
 		loc = time.UTC
 	} else {
 		slog.Info("Timezone set", "timezone", timezoneStr)

--- a/internal/validator/alerter.go
+++ b/internal/validator/alerter.go
@@ -92,7 +92,7 @@ func validateGUIDField(value, fieldName string) error {
 		return fmt.Errorf("%s is required", fieldName)
 	}
 	if !guidPattern.MatchString(value) {
-		return fmt.Errorf("%s must be a valid GUID", fieldName)
+		return fmt.Errorf("%s must be a valid guid", fieldName)
 	}
 	return nil
 }
@@ -316,7 +316,7 @@ func (a *Alerter) sendWithRetry(ctx context.Context, message *graphMailRequest) 
 			continue
 		default:
 			// Non-retryable error.
-			return fmt.Errorf("graph API error %d: %s", resp.StatusCode, respText)
+			return fmt.Errorf("graph api error %d: %s", resp.StatusCode, respText)
 		}
 	}
 

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -129,7 +129,8 @@ func (m *Manager) Enqueue(filePath, station, timestamp string) {
 func (m *Manager) scanUnvalidated() {
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("panic in scanUnvalidated; some stations may not have been scanned", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("panic in scanUnvalidated; some stations may not have been scanned",
+				"panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -129,7 +129,7 @@ func (m *Manager) Enqueue(filePath, station, timestamp string) {
 func (m *Manager) scanUnvalidated() {
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("panic in scanUnvalidated", "panic", r, "stack", string(debug.Stack()))
+			slog.Error("panic in scanUnvalidated; some stations may not have been scanned", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"time"
 
 	"github.com/oszuidwest/zwfm-audiologger/internal/config"
@@ -126,6 +127,12 @@ func (m *Manager) Enqueue(filePath, station, timestamp string) {
 
 // scanUnvalidated finds recordings without validation files and queues them.
 func (m *Manager) scanUnvalidated() {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("panic in scanUnvalidated", "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
+
 	slog.Info("Scanning for unvalidated recordings")
 
 	for stationName := range m.config.Stations {

--- a/main.go
+++ b/main.go
@@ -58,9 +58,7 @@ func main() {
 	}
 
 	// Set the timezone from config
-	if err := utils.SetTimezone(cfg.Timezone); err != nil {
-		slog.Warn("failed to set timezone", "error", err)
-	}
+	utils.SetTimezone(cfg.Timezone)
 
 	// Create context for graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary

**Error handling:**
- `SetTimezone` logged a warning internally on failure *and* returned the error, causing `main.go` to log it a second time — dropped the error return since the UTC fallback is fully handled inside the function
- Added `defer recover()` to `saveMetadata` and `scanUnvalidated` goroutines — an unrecovered panic in a goroutine crashes the entire process; these now follow the same pattern already used in the scheduler

**Naming conventions:**
- Lowercased acronyms in error strings (`FFmpeg` → `ffmpeg`, `GUID` → `guid`, `API` → `api`) per Go convention (error strings must be fully lowercase)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes