### PR TITLE
fix: close access log on listen failure

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -85,6 +85,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// Wait for context cancellation or server error.
 	select {
 	case err := <-errCh:
+		s.closeAccessLogFile()
 		return err
 	case <-ctx.Done():
 	}
@@ -101,17 +102,28 @@ func (s *Server) Start(ctx context.Context) error {
 	// Close the access log file only after a clean shutdown.
 	// If Shutdown timed out, handlers may still be writing to the log;
 	// closing early would silently discard those log entries.
-	// On a forced exit the OS flushes and closes the FD.
-	if shutdownErr == nil && s.accessLogFile != nil {
-		if err := s.accessLogFile.Close(); err != nil {
-			slog.Error("failed to close access log file", "error", err)
-		}
+	// On a forced exit, the FD remains open until the process exits and the OS
+	// flushes and closes it.
+	if shutdownErr == nil {
+		s.closeAccessLogFile()
 	}
 
 	if shutdownErr != nil {
 		return shutdownErr
 	}
 	return ctx.Err()
+}
+
+// closeAccessLogFile closes the access log file, clears the field, and is safe to call repeatedly.
+func (s *Server) closeAccessLogFile() {
+	if s.accessLogFile == nil {
+		return
+	}
+	path := s.accessLogFile.Name()
+	if err := s.accessLogFile.Close(); err != nil {
+		slog.Error("failed to close access log file", "path", path, "error", err)
+	}
+	s.accessLogFile = nil
 }
 
 // loggingMiddleware logs HTTP requests.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/oszuidwest/zwfm-audiologger/internal/config"
+)
+
+func TestStartClosesAccessLogFileWhenListenFails(t *testing.T) {
+	accessLogFile, err := os.CreateTemp(t.TempDir(), "access-*.log")
+	if err != nil {
+		t.Fatalf("create access log: %v", err)
+	}
+	// The server should close this first; cleanup is only a fallback.
+	t.Cleanup(func() { _ = accessLogFile.Close() })
+
+	s := &Server{
+		config:        &config.Config{Port: -1},
+		mux:           http.NewServeMux(),
+		accessLogger:  slog.New(slog.NewJSONHandler(accessLogFile, nil)),
+		accessLogFile: accessLogFile,
+	}
+
+	if err := s.Start(context.Background()); err == nil {
+		t.Fatal("Start returned nil error for invalid listen address")
+	}
+
+	if _, err := accessLogFile.WriteString("after close"); err == nil {
+		t.Fatal("access log file is still open after ListenAndServe failure")
+	}
+	if s.accessLogFile != nil {
+		t.Fatal("server still keeps a closed access log file reference")
+	}
+}
+
+func TestStartClosesAccessLogFileAfterCleanShutdown(t *testing.T) {
+	port := freeLocalPort(t)
+	accessLogFile, err := os.CreateTemp(t.TempDir(), "access-*.log")
+	if err != nil {
+		t.Fatalf("create access log: %v", err)
+	}
+	// The server should close this first; cleanup is only a fallback.
+	t.Cleanup(func() { _ = accessLogFile.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &Server{
+		config:        &config.Config{Port: port},
+		mux:           http.NewServeMux(),
+		accessLogger:  slog.New(slog.NewJSONHandler(accessLogFile, nil)),
+		accessLogFile: accessLogFile,
+	}
+	s.setupRoutes()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Start(ctx)
+	}()
+
+	waitForHealth(t, port, errCh)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Start error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+	if _, err := accessLogFile.WriteString("after close"); err == nil {
+		t.Fatal("access log file is still open after clean shutdown")
+	}
+	if s.accessLogFile != nil {
+		t.Fatal("server still keeps a closed access log file reference")
+	}
+}
+
+func TestCloseAccessLogFileAllowsNilFile(t *testing.T) {
+	s := &Server{}
+
+	s.closeAccessLogFile()
+
+	if s.accessLogFile != nil {
+		t.Fatal("nil access log file should remain nil")
+	}
+}
+
+func freeLocalPort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on free port: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func waitForHealth(t *testing.T, port int, errCh <-chan error) {
+	t.Helper()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/health", port)
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	for range 50 {
+		select {
+		case err := <-errCh:
+			t.Fatalf("Start returned before server became healthy: %v", err)
+		default:
+		}
+
+		resp, err := client.Get(url) //nolint:gosec // Test probe against local server startup.
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		select {
+		case err := <-errCh:
+			t.Fatalf("Start returned before server became healthy: %v", err)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	t.Fatalf("server did not become healthy at %s", url)
+}


### PR DESCRIPTION
## Summary
- close the access log file when ListenAndServe returns before shutdown
- centralize access log file closing and clear the stored file reference
- add a regression test for the occupied-port failure path

## Tests
- go test ./...

Closes #44