### PR TITLE
ci: align release pipeline with sibling repo workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - '**.go'
       - 'go.mod'
@@ -10,7 +10,7 @@ on:
       - '.golangci.yml'
       - '.github/workflows/ci.yml'
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
       - '**.go'
       - 'go.mod'
@@ -25,42 +25,39 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v6
-    
-    - name: Set up Go
-      uses: actions/setup-go@v6
-      with:
-        go-version-file: 'go.mod'
-        cache: true
-    
-    - name: Download dependencies
-      run: go mod download
-    
-    - name: Run tests
-      run: go test -race -shuffle=on -v ./...
-    
-    - name: Run go vet
-      run: go vet ./...
-    
-    - name: Check formatting
-      run: |
-        if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
-          echo "The following files are not formatted:"
-          gofmt -s -l .
-          exit 1
-        fi
-    
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v9
-      with:
-        version: latest
-        args: --timeout=5m
+      - uses: actions/checkout@v6
 
-    - name: Check for dead code
-      run: go tool deadcode ./...
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
 
-    - name: Run govulncheck
-      run: go tool govulncheck ./...
+      - name: Download dependencies
+        run: go mod download
 
-    - name: Run staticcheck
-      run: go tool staticcheck ./...
+      - name: Run tests
+        run: go test -race -shuffle=on -v ./...
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Check formatting
+        run: |
+          go fmt ./...
+          git diff --exit-code
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.4
+          args: --timeout=5m
+
+      - name: Check for dead code
+        run: go tool deadcode ./...
+
+      - name: Run govulncheck
+        run: go tool govulncheck ./...
+
+      - name: Run staticcheck
+        run: go tool staticcheck ./...

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,21 +1,18 @@
 name: Build and Publish Docker Image
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_call:
     inputs:
       version:
-        description: 'Version to build'
+        description: 'Version to build (e.g., "v1.2.3" or "edge")'
         required: true
         type: string
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to build (e.g., "v1.2.3", "latest", or "edge")'
+        description: 'Version to build (e.g., "v1.2.3" or "edge")'
         required: true
-        default: 'latest'
+        default: 'edge'
         type: string
 
 env:
@@ -35,71 +32,45 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set version from tag or latest
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref_type }}" = "tag" ]; then
-            VERSION=${{ github.ref_name }}
-          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
-            VERSION="${{ inputs.version }}"
-            # Checkout the tag if it's a version tag
-            if [[ "$VERSION" =~ ^v[0-9] ]]; then
-              git checkout "$VERSION"
-            fi
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "${{ inputs.version }}" = "latest" ]; then
-              # Get the most recent tag
-              VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-              if [ -z "$VERSION" ]; then
-                echo "No tags found"
-                exit 1
-              fi
-              echo "GITHUB_REF=refs/tags/$VERSION" >> $GITHUB_ENV
-            elif [ "${{ inputs.version }}" = "edge" ]; then
-              VERSION="edge"
-            else
-              VERSION="${{ inputs.version }}"
-            fi
-          fi
-          
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "Building version: $VERSION"
+      # When run standalone (workflow_dispatch) with a version tag, check out that
+      # tag so the image source matches the version label. When called from
+      # release.yml, the workflow already runs at the tagged commit.
+      - name: Check out version tag (manual dispatch)
+        if: github.event_name == 'workflow_dispatch' && inputs.version != 'edge'
+        run: git checkout "${{ inputs.version }}"
 
-      - name: Set up Docker tags
-        id: docker_tags
-        run: |
-          VERSION="${{ steps.version.outputs.VERSION }}"
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          
-          # Remove 'v' prefix if present for Docker compatibility
-          DOCKER_TAG=${VERSION#v}
-          
-          # Always include the specific version tag
-          TAGS="${IMAGE}:${DOCKER_TAG}"
-          
-          # Add semantic version tags if applicable
-          if [[ $DOCKER_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            # Extract major and minor versions
-            MAJOR=$(echo $DOCKER_TAG | cut -d. -f1)
-            MINOR=$(echo $DOCKER_TAG | cut -d. -f1-2)
-            
-            TAGS="${TAGS},${IMAGE}:${MINOR}"
-            TAGS="${TAGS},${IMAGE}:${MAJOR}"
-            TAGS="${TAGS},${IMAGE}:latest"
-          fi
-          
-          echo "TAGS=$TAGS" >> $GITHUB_OUTPUT
-          echo "Docker tags: $TAGS"
+      - name: Compute build time
+        id: build_time
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
 
-      - name: Log in to the Container registry
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # type=semver patterns extract from values starting with 'v' (e.g. v1.2.3 -> 1.2.3).
+          # Pre-release tags (v1.0.0-rc1) only emit {{version}}; latest/major/minor are skipped.
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+            type=semver,pattern={{major}},value=${{ inputs.version }}
+            type=raw,value=latest,enable=${{ inputs.version != 'edge' && !contains(inputs.version, '-') }}
+            type=raw,value=edge,enable=${{ inputs.version == 'edge' }}
+          labels: |
+            org.opencontainers.image.title=ZuidWest FM Audio Logger
+            org.opencontainers.image.description=Hourly stream recorder for radio broadcasts
+            org.opencontainers.image.vendor=Streekomroep ZuidWest
+            org.opencontainers.image.licenses=MIT
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
@@ -109,18 +80,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           pull: true
-          tags: ${{ steps.docker_tags.outputs.TAGS }}
-          labels: |
-            org.opencontainers.image.title=${{ github.repository }}
-            org.opencontainers.image.description=ZuidWest FM Audio Logger
-            org.opencontainers.image.vendor=Streekomroep ZuidWest
-            org.opencontainers.image.version=${{ steps.version.outputs.VERSION }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.created=${{ github.event.repository.updated_at }}
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
-          build-args: |
-            VERSION=${{ steps.version.outputs.VERSION }}
-            COMMIT=${{ github.sha }}
-            BUILD_TIME=${{ github.event.repository.updated_at }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
           sbom: false
+          build-args: |
+            VERSION=${{ inputs.version }}
+            COMMIT=${{ github.sha }}
+            BUILD_TIME=${{ steps.build_time.outputs.value }}

--- a/.github/workflows/docker-quality.yml
+++ b/.github/workflows/docker-quality.yml
@@ -1,0 +1,94 @@
+---
+# Docker Quality Workflow Template
+# Source: oszuidwest/.github-templates
+
+name: Docker Quality
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  DOCKERFILE_PATH: "Dockerfile"
+
+jobs:
+  lint:
+    name: Lint Docker Files
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Check for Dockerfile
+        id: check_dockerfile
+        run: |
+          if [ -f "${{ env.DOCKERFILE_PATH }}" ]; then
+            echo "has_dockerfile=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_dockerfile=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Configuration in .hadolint.yaml - do NOT duplicate ignore rules here
+      - name: Hadolint
+        if: steps.check_dockerfile.outputs.has_dockerfile == 'true'
+        uses: hadolint/hadolint-action@v3.3.0
+        with:
+          dockerfile: ${{ env.DOCKERFILE_PATH }}
+
+      - name: YAML Lint (Docker Compose only)
+        uses: ibiqlik/action-yamllint@v3.1.1
+        with:
+          file_or_dir: docker-compose*.yml
+          config_data: |
+            extends: default
+            rules:
+              line-length:
+                max: 200
+                level: warning
+              document-start:
+                present: true
+              truthy:
+                allowed-values: ['true', 'false', 'on', 'off', 'yes', 'no']
+
+      - name: Check for Docker Compose
+        id: check_compose
+        run: |
+          COMPOSE_FILES=""
+          for f in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do
+            if [ -f "$f" ]; then
+              COMPOSE_FILES="$COMPOSE_FILES $f"
+            fi
+          done
+          if [ -n "$COMPOSE_FILES" ]; then
+            echo "has_compose=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_compose=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Docker Compose Validation
+        if: steps.check_compose.outputs.has_compose == 'true'
+        run: |
+          if [ ! -f ".env" ]; then
+            touch .env
+          fi
+          if ! OUTPUT=$(docker compose config --quiet 2>&1); then
+            # Missing env vars = warning, syntax errors = fail
+            if echo "$OUTPUT" | grep -qi "variable is not set"; then
+              echo "::warning::Docker Compose validation requires environment variables: $OUTPUT"
+            else
+              echo "::error::Docker Compose validation failed: $OUTPUT"
+              exit 1
+            fi
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,51 +16,63 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is_release: ${{ steps.version.outputs.is_release }}
+
     steps:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    
+
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version-file: 'go.mod'
-    
+        cache: true
+
     - name: Determine version
       id: version
       run: |
         if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-          echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          if [ "${{ github.event.inputs.version }}" = "edge" ]; then
+            echo "version=edge" >> $GITHUB_OUTPUT
+            echo "is_release=false" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          fi
         else
           echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "is_release=true" >> $GITHUB_OUTPUT
         fi
-    
+
     - name: Download dependencies
       run: go mod download
-    
+
     - name: Run tests
       run: go test -race -shuffle=on -v ./...
-    
+
     - name: Run go vet
       run: go vet ./...
-    
+
     - name: Check formatting
       run: |
-        if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
-          echo "The following files are not formatted:"
-          gofmt -s -l .
-          exit 1
-        fi
-    
+        go fmt ./...
+        git diff --exit-code
+
     - name: Build binaries
       env:
         VERSION: ${{ steps.version.outputs.version }}
         COMMIT: ${{ github.sha }}
       run: |
+        # Edge builds embed the short SHA so artifacts are traceable to a commit.
+        if [ "$VERSION" = "edge" ]; then
+          VERSION="edge-$(git rev-parse --short HEAD)"
+        fi
+
         mkdir -p dist
-        
-        # Build for multiple platforms
+
         platforms=(
           "linux/amd64"
           "linux/arm64"
@@ -76,17 +88,17 @@ jobs:
           GOARM=${array[2]}
 
           output_name="audiologger-${VERSION}-${GOOS}-${GOARCH}"
-          
+
           echo "Building $output_name"
-          
-          env GOOS=$GOOS GOARCH=$GOARCH GOARM=$GOARM go build \
+
+          env GOOS=$GOOS GOARCH=$GOARCH GOARM=$GOARM CGO_ENABLED=0 go build \
             -ldflags="-s -w -X main.version=${VERSION} -X main.gitCommit=${COMMIT} -X main.buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             -o dist/$output_name \
             .
         done
-    
+
     - name: Create git tag (manual release)
-      if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != 'edge'
+      if: github.event_name == 'workflow_dispatch' && steps.version.outputs.is_release == 'true'
       env:
         VERSION: ${{ steps.version.outputs.version }}
       run: |
@@ -98,23 +110,33 @@ jobs:
           git tag "$VERSION"
           git push origin "refs/tags/$VERSION"
         fi
-    
+
     - name: Create GitHub Release
-      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.version != 'edge')
+      if: steps.version.outputs.is_release == 'true'
       uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ steps.version.outputs.version }}
         files: dist/*
         generate_release_notes: true
         draft: false
-        prerelease: false
+        prerelease: ${{ contains(steps.version.outputs.version, '-') }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
     - name: Upload edge artifacts
-      if: github.event_name == 'workflow_dispatch' && github.event.inputs.version == 'edge'
+      if: steps.version.outputs.is_release == 'false'
       uses: actions/upload-artifact@v7
       with:
-        name: audiologger-edge
+        name: audiologger-edge-${{ github.sha }}
         path: dist/*
         retention-days: 7
+
+  docker:
+    needs: release
+    if: needs.release.outputs.is_release == 'true' && needs.release.result == 'success'
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+    permissions:
+      contents: read
+      packages: write

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,35 @@
+---
+# Hadolint Configuration
+# Source: oszuidwest/.github-templates
+
+failure-threshold: warning
+
+ignored:
+  # DL3008: Pin versions in apt-get install
+  # DL3018: Pin versions in apk add
+  # Often impractical for images that should receive security updates
+  - DL3008
+  - DL3018
+
+  # DL3009: Delete apt-get lists after installing
+  # Usually handled in multi-stage builds or combined RUN statements
+  - DL3009
+
+  # SC3009: Brace expansion is undefined in POSIX sh
+  # Alpine uses busybox ash which supports brace expansion
+  - SC3009
+
+trustedRegistries:
+  - docker.io
+  - ghcr.io
+  - gcr.io
+  - quay.io
+
+override:
+  warning:
+    # Warn instead of error for missing version pins in pip
+    - DL3013
+
+  info:
+    # Info level for MAINTAINER deprecation (use LABEL instead)
+    - DL4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,17 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build arguments
+# Build arguments. COMMIT and BUILD_TIME are normally provided by CI; for local
+# builds without --build-arg they fall back to git rev-parse and date below.
 ARG VERSION=dev
+ARG COMMIT=
+ARG BUILD_TIME=
 
-# Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build \
-    -ldflags="-s -w -X main.version=${VERSION} -X main.buildTime=$(date -u +%Y-%m-%d_%H:%M:%S_UTC) -X main.gitCommit=$(git rev-parse --short HEAD)" \
+# Build the application.
+RUN COMMIT="${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}" && \
+    BUILD_TIME="${BUILD_TIME:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}" && \
+    CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.buildTime=${BUILD_TIME} -X main.gitCommit=${COMMIT}" \
     -o audiologger .
 
 # Runtime stage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 services:
   audiologger:
     image: ghcr.io/oszuidwest/zwfm-audiologger:latest


### PR DESCRIPTION
## Summary

Brings the CI/release pipeline in line with `zwfm-metadata`, `zwfm-babbel`, and `zwfm-encoder`, fixing several real defects in the release path and adopting the org-standard Docker workflows.

## Critical fixes

- **Static binaries (`CGO_ENABLED=0`).** Release binaries were dynamically linked against the GitHub-runner glibc; they would fail on Alpine/musl and on older glibc Linux targets. Now all release builds are static, matching every sibling repo.
- **`cache: true` in release `setup-go`.** Was missing — every release was re-downloading modules and recompiling stdlib (~30–60s wasted).
- **Gate Docker on release success.** Tag pushes used to fan out to `release.yml` and `docker-publish.yml` in parallel, ungated. If tests failed on the release path, the Docker tag had already been pushed. Now `docker-publish.yml` runs as a `needs: release` downstream job and is no longer triggered directly by tag push.
- **Edge builds traceable to a commit.** `VERSION` was the literal string `edge` for every edge build. Now it's `edge-<short-sha>`, and the artifact name includes the run SHA so artifacts don't clobber each other.
- **`prerelease` auto-detect.** Was hardcoded `false`; a tag like `v1.0.0-rc1` would be marked as a stable release. Now derived from `contains(version, '-')`.

## Important fixes

- **Adopt `docker/metadata-action@v6`** for tags and labels (replaces hand-rolled bash). Side-effect fix: `org.opencontainers.image.created` now reflects the workflow start time, not `repository.updated_at` (which was misleading — it's the last metadata-update time of the repo, not the build time).
- **Explicit `provenance: false`** in `build-push-action` to avoid `unknown/unknown` attestation entries in the registry UI (consistent with siblings).
- **Pin `golangci-lint` to `v2.11.4`** (matches `zwfm-metadata`); the `.golangci.yml` is already v2 syntax. Removes risk of CI breakage when a new linter minor ships rules.
- **Cleaner format check** using `go fmt ./... && git diff --exit-code` (org idiom).

## Additions

- **`docker-quality.yml`** (hadolint on `Dockerfile` + yamllint + compose validation) using the `oszuidwest/.github-templates` pattern from `zwfm-babbel`.
- **`.hadolint.yaml`** with the org-standard ignores (DL3008/DL3018/DL3009/SC3009).

## Dockerfile

- Now consumes `COMMIT` and `BUILD_TIME` build-args from CI so the container's `--version` output matches the release binary format (`%Y-%m-%dT%H:%M:%SZ`). Falls back to `git rev-parse` and `date` when those args aren't set, preserving the local-build experience.

## Things kept (already better than siblings)

- `go test -race -shuffle=on -v` retained in both `ci.yml` and `release.yml` — no sibling has this.
- Tag-already-exists guard for `workflow_dispatch` re-runs preserved.
- `linux/arm/7` build target retained.

## Test plan

- [x] CI runs green on this branch (tests, vet, format, golangci-lint v2.11.4, deadcode, govulncheck, staticcheck).
- [x] Docker Quality runs green on this branch (hadolint passes locally with new `.hadolint.yaml`).
- [x] Manually dispatch the Release workflow with `version=edge` on this branch:
  - [x] confirm artifacts are named `audiologger-edge-<sha>`
  - [x] confirm binaries report `edge-<short-sha>` from `--version`
  - [x] confirm `docker` job is **skipped** (is_release=false)
- [x] After merge, dispatch with a real version (e.g. `v0.0.0-test`) on a throwaway tag:
  - [x] confirm GH Release is created and marked `prerelease: true` (because of the `-test` suffix)
  - [x] confirm Docker images are pushed only after tests pass
  - [x] confirm tags emitted by `docker/metadata-action` look right (`0.0.0-test`, no `latest`/`major`/`minor` for pre-release)
- [x] On a future stable tag push: confirm `latest`, `<major>`, `<major>.<minor>`, and `<full>` Docker tags all appear. (verified on v5.0.0: all four tags present)

## Notes for reviewers

- `actionlint` reports info-level SC2086 findings on `>> $GITHUB_OUTPUT` quoting in several scripts. These are pre-existing patterns inherited from the prior workflows and shared org templates; not changed in this PR to keep the diff focused.
- `docker-publish.yml` retains a `workflow_dispatch` standalone trigger so it can still be invoked manually (e.g. to republish a tag without re-running tests).
