### PR TITLE
docs: rewrite README around reliability and v5.0 reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,30 @@
 # ZuidWest FM Audio Logger
 
-An automated broadcast recording system designed for radio station compliance logging and program archival.
+Hourly broadcast recorder, designed for compliance archives where missing an hour is not an option. A single Go binary captures one or more radio streams, validates each finished recording, alerts on anything suspicious, and serves the archive over HTTP.
 
-## Features
+This is what runs at Streekomroep ZuidWest. Every reliability feature in the codebase exists because some real failure mode cost us a recording at some point.
 
-- **Automated hourly recording** with runtime audio format detection (MP3, AAC, OGG, OPUS, FLAC)
-- **Multi-station support** with concurrent stream recording
-- **Broadcast metadata extraction** from external playout APIs
-- **Web-based file browser** for accessing and downloading recordings
-- **Automatic retention management** with configurable cleanup schedules
+## Reliability features
 
-## Requirements
+- **Catchup on startup.** If the process starts mid-hour with at least 60 seconds remaining in the slot, it begins recording immediately rather than waiting for the next hour. A restart never costs you a partial hour.
+- **Disk-space guard.** Refuses to start a new recording when free space drops below 1 GB, instead of silently writing zero-byte files until the volume fills.
+- **Post-recording validation.** Each finished file is analyzed for silence (`ffmpeg silencedetect`) and looped content (RMS autocorrelation). Files that look broken are flagged.
+- **Failure alerts.** Recording failures and validation failures send email via Microsoft Graph, retried with exponential backoff (3 attempts, 1s to 30s). Recipients can be routed per station.
+- **Internal scheduler.** No reliance on system cron. The Go process owns its own schedule and shuts down gracefully on SIGTERM.
+- **Format detection at remux time.** `ffprobe` decides the actual container, so a station that switches codec mid-day still produces a valid file in the right wrapper.
+- **Structured logging.** JSON output via `log/slog`, suitable for ingestion into any log pipeline.
 
-- Go 1.26.2 or higher
-- FFmpeg and ffprobe
+## Recording flow
 
-## Installation
-
-```bash
-git clone https://github.com/oszuidwest/zwfm-audiologger.git
-cd zwfm-audiologger
-go build -o audiologger .
-```
+1. At minute 0 of every hour, each configured stream is captured to a temporary `.mkv` file for one hour.
+2. `ffprobe` detects the actual codec.
+3. The file is remuxed into the appropriate container (`.mp3`, `.aac`, `.ogg`, `.opus`, `.flac`).
+4. If validation is enabled, the file is analyzed. Broken files are flagged and, when configured, emailed.
+5. A daily cleanup job removes recordings older than `keep_days`.
 
 ## Configuration
 
-The application requires a `config.json` file in the working directory:
+The application looks for `config.json` in the working directory. Override with `-config /path/to/config.json`.
 
 ```json
 {
@@ -44,87 +43,128 @@ The application requires a `config.json` file in the working directory:
 }
 ```
 
-The repository `config.json` uses placeholder URLs. Mount or provide a deployment-specific config file for production streams.
-
-### Configuration Options
+### Top level
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `recordings_dir` | string | `/var/audio` | Storage directory for recordings |
-| `port` | int | `8080` | HTTP server listening port |
-| `keep_days` | int | `31` | Retention period in days before automatic deletion |
-| `timezone` | string | `UTC` | Timezone for scheduling operations |
-| `stations` | object | required | Station configuration map |
+| `recordings_dir` | string | `/var/audio` | Directory where recordings are written. |
+| `port` | int | `8080` | HTTP server listen port. |
+| `keep_days` | int | `31` | Days to retain recordings before cleanup. |
+| `timezone` | string | `UTC` | Timezone for hour-of-day scheduling. |
+| `stations` | object | required | Map of station ID to station config. |
+| `validation` | object | optional | Enables post-recording validation and alerts. See below. |
 
-### Station Configuration
+### Per station
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `stream_url` | string | Yes | Broadcast stream URL |
-| `metadata_url` | string | No | Playout system metadata API endpoint |
-| `metadata_path` | string | No | JSON path for metadata extraction (dot notation) |
-| `parse_metadata` | bool | No | Enable JSON parsing of metadata response (default: false) |
+| `stream_url` | string | yes | The stream to capture. |
+| `metadata_url` | string | no | Optional now-playing API endpoint. |
+| `metadata_path` | string | no | JSON dot-path used to extract the metadata value. No leading dot. |
+| `parse_metadata` | bool | no | If true, fetch and parse JSON. If false, no metadata file is written. |
 
-## Usage
+### Validation (optional)
 
-```bash
-./audiologger                              # Run with default config.json
-./audiologger -config /path/to/config.json # Specify custom configuration file
-./audiologger -test                        # Test mode with 10-second recordings
-./audiologger -version                     # Display version information
+Add a `validation` block to enable silence and loop analysis on every recording, with optional email alerts.
+
+```json
+{
+  "validation": {
+    "enabled": true,
+    "min_duration_secs": 3500,
+    "silence_threshold_db": -40.0,
+    "max_silence_secs": 5.0,
+    "max_loop_percent": 30.0,
+    "alert": {
+      "enabled": true,
+      "tenant_id": "...",
+      "client_id": "...",
+      "client_secret": "...",
+      "sender_email": "alerts@example.com",
+      "default_recipients": ["ops@example.com"]
+    },
+    "station_recipients": {
+      "station1": ["station1-team@example.com"]
+    }
+  }
+}
 ```
 
-## API Endpoints
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `false` | Master switch for validation. |
+| `min_duration_secs` | `3500` | Recordings shorter than this are flagged. |
+| `silence_threshold_db` | `-40.0` | dB level below which audio is considered silent. |
+| `max_silence_secs` | `5.0` | Max continuous silence allowed before flagging. |
+| `max_loop_percent` | `30.0` | Max share of audio that may resemble a loop. |
+| `alert.*` | | Microsoft Graph credentials for sending email alerts. |
+| `station_recipients` | | Per-station override of `default_recipients`. |
+
+## Running
+
+### Docker
+
+```yaml
+services:
+  audiologger:
+    image: ghcr.io/oszuidwest/zwfm-audiologger:latest
+    container_name: audiologger
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - audiologger-data:/var/audio
+      - ./config.json:/app/config.json:ro
+    environment:
+      - TZ=Europe/Amsterdam
+
+volumes:
+  audiologger-data:
+```
+
+The image is published as multi-arch (`linux/amd64`, `linux/arm64`) on every release. Tags follow SemVer: `5.0.0`, `5.0`, `5`, and `latest`.
+
+### Binary
+
+```bash
+./audiologger                              # uses config.json in cwd
+./audiologger -config /path/to/config.json
+./audiologger -test                        # 10-second recordings, for verification
+./audiologger -version
+```
+
+Pre-built binaries for `linux/amd64`, `linux/arm64`, `linux/arm/7`, `darwin/amd64`, and `darwin/arm64` are attached to every GitHub Release.
+
+## HTTP API
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/health` | Health check endpoint |
-| GET | `/status` | System status information |
-| GET | `/recordings/{path...}` | File browser and download interface |
+| GET | `/health` | Liveness check. Returns `200 OK`. |
+| GET | `/status` | Process heartbeat and current time, as JSON. |
+| GET | `/recordings/{path...}` | Browse and download the recordings tree. |
 
-## How It Works
-
-### Recording Process
-
-The system operates on an hourly schedule, executing the following steps:
-
-1. **Stream capture** - Records broadcast streams to temporary `.mkv` container files at the top of each hour
-2. **Format detection** - Analyzes codec using `ffprobe` to determine the actual audio format
-3. **Container remuxing** - Converts to the appropriate container format (`.mp3`, `.aac`, `.ogg`, `.opus`, `.flac`)
-4. **Retention management** - Performs daily cleanup to remove recordings exceeding the retention period
-
-## File Structure
+## Storage layout
 
 ```
 /var/audio/
 ├── station1/
-│   ├── 2024-01-15-14.mp3              # Hourly recording
-│   └── 2024-01-15-14.meta             # Broadcast metadata from playout system
-```
-
-## Docker Deployment
-
-```yaml
-version: '3.8'
-services:
-  audiologger:
-    build: .
-    volumes:
-      - ./recordings:/var/audio
-      - ./config.json:/config.json:ro
-    ports:
-      - "8080:8080"
-    restart: unless-stopped
+│   ├── 2026-04-30-22.mp3      # hourly recording, container chosen by codec
+│   └── 2026-04-30-22.meta     # metadata sidecar, written when metadata_url is set
+└── station2/
+    └── ...
 ```
 
 ## Development
 
 ```bash
-go test -race ./... # Execute test suite with race detection
-go fmt ./...      # Format source code
-go vet ./...      # Run static analysis
-deadcode ./...    # Detect unreachable code
+go build -o audiologger .
+go test -race -shuffle=on ./...
+go fmt ./...
+go vet ./...
+golangci-lint run --timeout=5m
 ```
+
+Requires Go 1.26.2 or higher and `ffmpeg`/`ffprobe` available in `PATH`.
 
 ## License
 


### PR DESCRIPTION
## Summary

Rewrites the README to lead with what the project is actually for (broadcast compliance recording where missing an hour is unacceptable) and to describe the v5.0 reality (Go binary, multi-arch image, validation pipeline, alerts) instead of a generic "automated recording system" framing.

## What changes

- **New opening.** States the purpose and the operational stakes in two sentences. Avoids the previous generic phrasing.
- **New "Reliability features" section.** Documents the mechanisms that already exist in the code but were not surfaced anywhere: catchup-on-startup, disk-space guard (1 GB floor), post-recording validation (silence + loop autocorrelation), Microsoft Graph email alerts with retry, internal scheduler, codec auto-detection at remux time, structured logging.
- **Validation block documented.** The `validation` and nested `alert` config blocks were undocumented. Added schema, defaults sourced directly from `internal/constants`, and an example with per-station recipient routing.
- **Docker section uses the published image.** `image: ghcr.io/oszuidwest/zwfm-audiologger:latest` instead of `build: .`. Removed the obsolete `version: '3.8'` Compose attribute. Mount path corrected to `/app/config.json` to match `Dockerfile` and the in-repo `docker-compose.yml`. Notes the SemVer tag scheme established in #47.
- **Binary section** mentions the multi-platform release artifacts produced by `release.yml`.
- **HTTP API table** is honest about what `/status` actually returns today (heartbeat + time, not the richer payload the previous wording hinted at).
- **Storage example** uses a plausible v5-era timestamp.

## What stays accurate

- Config field semantics, defaults, and types match `internal/config/config.go` and `internal/constants/constants.go` as of `main`.
- All flags (`-config`, `-test`, `-version`) match `main.go`.
- Endpoint list matches `internal/server/server.go`.

## Test plan

- [ ] Render the README on the PR page and confirm tables render cleanly.
- [ ] Spot-check the validation example by loading it as `config.json` locally with `./audiologger -test` (no actual streams hit).

## Notes

- No code changes. Pure docs.
- Drafted with the project context that v5.0.0 was just released and earlier user-facing material framed the project as if it were still the bash-era tool.