### PR TITLE
ci: sync docker-quality.yml with current template

### DIFF
--- a/.github/workflows/docker-quality.yml
+++ b/.github/workflows/docker-quality.yml
@@ -1,6 +1,16 @@
 ---
 # Docker Quality Workflow Template
 # Source: oszuidwest/.github-templates
+#
+# This workflow lints Dockerfiles, validates YAML, and checks Docker Compose files.
+# Copy to: .github/workflows/docker-quality.yml
+#
+# Required config files:
+#   - .hadolint.yaml (at repo root)
+#
+# Customization:
+#   - DOCKERFILE_PATH: Change if Dockerfile is not at root (e.g., "docker/Dockerfile")
+#   - Adjust YAML lint rules in the inline config as needed
 
 name: Docker Quality
 
@@ -35,9 +45,9 @@ jobs:
         id: check_dockerfile
         run: |
           if [ -f "${{ env.DOCKERFILE_PATH }}" ]; then
-            echo "has_dockerfile=true" >> $GITHUB_OUTPUT
+            echo "has_dockerfile=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_dockerfile=false" >> $GITHUB_OUTPUT
+            echo "has_dockerfile=false" >> "$GITHUB_OUTPUT"
           fi
 
       # Configuration in .hadolint.yaml - do NOT duplicate ignore rules here
@@ -47,20 +57,21 @@ jobs:
         with:
           dockerfile: ${{ env.DOCKERFILE_PATH }}
 
-      - name: YAML Lint (Docker Compose only)
+      - name: YAML Lint
         uses: ibiqlik/action-yamllint@v3.1.1
         with:
-          file_or_dir: docker-compose*.yml
           config_data: |
             extends: default
             rules:
               line-length:
-                max: 200
+                max: 120
                 level: warning
-              document-start:
-                present: true
+              comments:
+                min-spaces-from-content: 1
               truthy:
                 allowed-values: ['true', 'false', 'on', 'off', 'yes', 'no']
+              document-start:
+                present: true
 
       - name: Check for Docker Compose
         id: check_compose
@@ -72,9 +83,9 @@ jobs:
             fi
           done
           if [ -n "$COMPOSE_FILES" ]; then
-            echo "has_compose=true" >> $GITHUB_OUTPUT
+            echo "has_compose=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_compose=false" >> $GITHUB_OUTPUT
+            echo "has_compose=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Docker Compose Validation


### PR DESCRIPTION
## Summary
- Replace audiologger's older `docker-quality.yml` (only linted `docker-compose*.yml`) with the current `oszuidwest/.github-templates` version that lints all YAML files in the repo
- Stricter inline yamllint config: line-length 120 (was 200), comments min-spaces-from-content, truthy allowed-values check
- Brings audiologger in line with metadata/babbel which already use the current template version

This was deliberately deferred per the Round 2 plan ("Audiologger optionele cosmetische convergentie ... Niet in Phase 1 strict; doe als losse PR ná tag v1.0.0"). Now that v1.1.0 is tagged and all consumers are on v1 shims, this is the cleanup follow-up.

Local yamllint preview against the new config showed 3 warning-level findings (missing `---` document-start on `.golangci.yml`, `.github/release.yml`, `.github/dependabot.yml`). These are warnings only — verified that `ibiqlik/action-yamllint@v3.1.1` does not fail CI on warnings (metadata + babbel have the same warnings, their docker-quality CI passes).

## Test plan
- [x] `actionlint .github/workflows/docker-quality.yml` — clean
- [x] CI on this branch passes (Docker Quality job runs against expanded YAML scope)