### PR TITLE
ci: migrate release shim to go-release.yml@v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 ---
-# Thin shim — delegates to oszuidwest/.github-templates go-release.yml@v1.
-# enable-docker: true triggers transitive docker-publish.yml@v1 for releases.
+# Thin shim — delegates to oszuidwest/.github-templates go-release.yml@v2.
+# Docker publishing is composed via a second job that calls
+# docker-publish.yml@v1 directly, gated on the release outputs.
 name: Release
 
-'on':
+on:
   push:
     tags:
       - 'v*'
@@ -19,7 +20,7 @@ permissions:
 
 jobs:
   release:
-    uses: oszuidwest/.github-templates/.github/workflows/go-release.yml@v1
+    uses: oszuidwest/.github-templates/.github/workflows/go-release.yml@v2
     with:
       project-name: audiologger
       ldflags-target: main
@@ -30,12 +31,20 @@ jobs:
          {"os":"darwin","arch":"amd64"},
          {"os":"darwin","arch":"arm64"}]
       version: ${{ inputs.version }}
-      enable-docker: true
+    permissions:
+      contents: write
+
+  docker:
+    needs: release
+    if: needs.release.outputs.is_release == 'true'
+    uses: oszuidwest/.github-templates/.github/workflows/docker-publish.yml@v1
+    with:
+      version: ${{ needs.release.outputs.version }}
       image-labels: |
         org.opencontainers.image.title=ZuidWest FM Audio Logger
         org.opencontainers.image.description=Hourly broadcast recorder
         org.opencontainers.image.vendor=Streekomroep ZuidWest
         org.opencontainers.image.licenses=MIT
     permissions:
-      contents: write
+      contents: read
       packages: write


### PR DESCRIPTION
## Summary

Bump release shim from `go-release.yml@v1` to `@v2`. v2 dropped the nested docker job, so this PR splits the shim into two jobs:

- `release` — calls `go-release.yml@v2` with no Docker-related inputs and `contents: write` only.
- `docker` — new job, calls `docker-publish.yml@v1` directly, gated on `needs.release.outputs.is_release == 'true'`. Carries the OCI labels and `packages: write` previously bundled into the release call.

Edge runs short-circuit at the `if:` so no Docker push happens for them (Phase 0: edge is artifacts-only).

Drive-by: drops legacy `'on':` quoting (the other zwfm-* shims got this in their respective #17 follow-ups; audiologger was missed).

Upstream: oszuidwest/.github-templates#18 (closes oszuidwest/.github-templates#5).

## Test plan

- [ ] After merge, smoke-test via `gh workflow run release.yml -f version=edge` → expect a fresh edge artifact, no Docker push, no parse-time errors.
- [ ] Next real release tag exercises the full Docker publish path; verify GHCR image is published with the same SHA as the binary.