### PR TITLE
ci: bump go-ci.yml shim from @v1 to @v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ---
-# Thin shim — delegates to oszuidwest/.github-templates go-ci.yml@v1.
+# Thin shim — delegates to oszuidwest/.github-templates go-ci.yml@v2.
 name: CI
 
 on:
@@ -25,6 +25,6 @@ permissions:
 
 jobs:
   ci:
-    uses: oszuidwest/.github-templates/.github/workflows/go-ci.yml@v1
+    uses: oszuidwest/.github-templates/.github/workflows/go-ci.yml@v2
     with:
       golangci-lint-version: v2.12.1


### PR DESCRIPTION
## Summary

- Bumps `oszuidwest/.github-templates/.github/workflows/go-ci.yml@v1` → `@v2` in the CI shim.
- Updates the corresponding inline comment.

No functional change: the v2 tag of `.github-templates` was a breaking change scoped to `go-release.yml` only — `go-ci.yml` content is identical between v1 and v2. This bump completes the v1 → v2 cutover so the v1 line can eventually be retired.

Context: oszuidwest/.github-templates#5, #18.

## Test plan

- [ ] CI green on PR (Go job runs via `go-ci.yml@v2`).