### PR TITLE
ci: bump docker-publish.yml ref from @v1 to @v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 ---
 # Thin shim — delegates to oszuidwest/.github-templates go-release.yml@v2.
 # Docker publishing is composed via a second job that calls
-# docker-publish.yml@v1 directly, gated on the release outputs.
+# docker-publish.yml@v2 directly, gated on the release outputs.
 name: Release
 
 on:
@@ -37,7 +37,7 @@ jobs:
   docker:
     needs: release
     if: needs.release.outputs.is_release == 'true'
-    uses: oszuidwest/.github-templates/.github/workflows/docker-publish.yml@v1
+    uses: oszuidwest/.github-templates/.github/workflows/docker-publish.yml@v2
     with:
       version: ${{ needs.release.outputs.version }}
       image-labels: |


### PR DESCRIPTION
## Summary

- Bumps `oszuidwest/.github-templates/.github/workflows/docker-publish.yml@v1` → `@v2` in the release workflow's `docker` job.

No functional change: `docker-publish.yml` itself was never breaking-changed — its content is identical at the v1 and v2 tags. This bump removes the last consumer reference to the v1 line so the v1 tag of `.github-templates` can be retired.

Context: oszuidwest/.github-templates#5, #18.

## Test plan

- [ ] CI green on PR.
- [ ] After merge: next tag push exercises the docker job via `@v2` end-to-end.