### PR TITLE
Move FFmpeg runtime to Debian 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,21 +28,24 @@ RUN COMMIT="${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}
     -o audiologger .
 
 # Runtime stage
-FROM alpine:3.23
+FROM debian:13-slim
 
 LABEL org.opencontainers.image.source="https://github.com/oszuidwest/zwfm-audiologger"
 LABEL org.opencontainers.image.description="ZuidWest FM audiologger"
 
-# Install runtime dependencies
-RUN apk --no-cache upgrade && \
-    apk add --no-cache \
-    ffmpeg \
-    ca-certificates \
-    tzdata
+ARG DEBIAN_FRONTEND=noninteractive
 
-# Create non-root user
-RUN addgroup -g 1001 audiologger && \
-    adduser -u 1001 -G audiologger -s /bin/sh -D audiologger
+# Install runtime dependencies.
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+    ca-certificates \
+    ffmpeg \
+    tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create non-root user.
+RUN groupadd --gid 1001 audiologger && \
+    useradd --uid 1001 --gid audiologger --home-dir /app --shell /usr/sbin/nologin --no-create-home audiologger
 
 # Set working directory
 WORKDIR /app
@@ -65,7 +68,7 @@ EXPOSE 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --timeout=3 -O /dev/null http://localhost:8080/health || exit 1
+    CMD ["/app/audiologger", "-healthcheck", "http://127.0.0.1:8080/health"]
 
 # Default command
-CMD ["./audiologger"]
+CMD ["/app/audiologger"]

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// healthcheckTimeout bounds the Docker healthcheck request.
+const healthcheckTimeout = 3 * time.Second
+
+// runHealthcheck probes the HTTP health endpoint and returns an error on failure.
+func runHealthcheck(ctx context.Context, targetURL string) error {
+	if targetURL == "" {
+		return fmt.Errorf("healthcheck URL is required")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, healthcheckTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("create healthcheck request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("perform healthcheck request: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // Healthcheck response close errors do not affect readiness.
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("healthcheck returned HTTP %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRunHealthcheck(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+	}{
+		{name: "ok", statusCode: http.StatusOK},
+		{name: "bad request", statusCode: http.StatusBadRequest, wantErr: true},
+		{name: "not found", statusCode: http.StatusNotFound, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer srv.Close()
+
+			err := runHealthcheck(context.Background(), srv.URL)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunHealthcheckRequiresURL(t *testing.T) {
+	t.Parallel()
+
+	if err := runHealthcheck(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	configFile := flag.String("config", "config.json", "Config file path")
 	testMode := flag.Bool("test", false, "Test recording (10 seconds)")
 	showVersion := flag.Bool("version", false, "Show version information")
+	healthcheckURL := flag.String("healthcheck", "", "Run HTTP healthcheck against URL and exit")
 	flag.Parse()
 
 	// Show version if requested
@@ -48,6 +49,14 @@ func main() {
 		fmt.Printf("Git Commit: %s\n", Commit)
 		fmt.Printf("Go Version: %s\n", runtime.Version())
 		fmt.Printf("Platform:   %s/%s\n", runtime.GOOS, runtime.GOARCH)
+		return
+	}
+
+	if *healthcheckURL != "" {
+		if err := runHealthcheck(context.Background(), *healthcheckURL); err != nil {
+			slog.Error("healthcheck failed", "error", err)
+			os.Exit(1)
+		}
 		return
 	}
 


### PR DESCRIPTION
## Summary
- switch the runtime image from Alpine 3.23 to Debian 13 slim with distro ffmpeg/ffprobe
- replace wget-based Docker healthcheck with the audiologger binary healthcheck
- add focused healthcheck tests for success and 4xx failures

## Size note
- local Debian 13 image: 209,002,102 bytes
- local Alpine baseline from origin/main: 63,834,248 bytes
- Debian 13 is larger because the distro ffmpeg package pulls in a broad runtime dependency set.

## Verification
- go test ./...
- go vet ./...
- golangci-lint run --timeout=5m
- hadolint --config .hadolint.yaml Dockerfile
- docker compose config --quiet
- docker build --pull -q -t zwfm-audiologger:debian13-local .
- docker run --rm --entrypoint /usr/bin/ffmpeg zwfm-audiologger:debian13-local -version
- docker run --rm --entrypoint /usr/bin/ffprobe zwfm-audiologger:debian13-local -version
- docker run --rm zwfm-audiologger:debian13-local /app/audiologger -version