### PR TITLE
Configure FFmpeg tool paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The application looks for `config.json` in the working directory. Override with 
   "port": 8080,
   "keep_days": 31,
   "timezone": "Europe/Amsterdam",
+  "ffmpeg_path": "ffmpeg",
+  "ffprobe_path": "ffprobe",
   "stations": {
     "station1": {
       "stream_url": "https://stream.example.com/station1.mp3",
@@ -51,6 +53,8 @@ The application looks for `config.json` in the working directory. Override with 
 | `port` | int | `8080` | HTTP server listen port. |
 | `keep_days` | int | `31` | Days to retain recordings before cleanup. |
 | `timezone` | string | `UTC` | Timezone for hour-of-day scheduling. |
+| `ffmpeg_path` | string | `ffmpeg` | FFmpeg executable path used for recording, remuxing, and validation. |
+| `ffprobe_path` | string | `ffprobe` | ffprobe executable path used for format detection and validation. |
 | `stations` | object | required | Map of station ID to station config. |
 | `validation` | object | optional | Enables post-recording validation and alerts. See below. |
 

--- a/config.json
+++ b/config.json
@@ -3,6 +3,8 @@
   "port": 8080,
   "keep_days": 31,
   "timezone": "Europe/Amsterdam",
+  "ffmpeg_path": "ffmpeg",
+  "ffprobe_path": "ffprobe",
   "stations": {
     "station1": {
       "stream_url": "https://stream.example.com/station1.mp3",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,11 +75,11 @@ func Load(path string) (*Config, error) {
 // Validate checks whether the loaded configuration can be used at runtime.
 func (c *Config) Validate() error {
 	if _, err := exec.LookPath(c.FFmpegPath); err != nil {
-		return fmt.Errorf("ffmpeg binary not found at %q: %w", c.FFmpegPath, err)
+		return fmt.Errorf("ffmpeg binary not found at %q: ensure ffmpeg_path in config.json points to a valid binary: %w", c.FFmpegPath, err)
 	}
 
 	if _, err := exec.LookPath(c.FFprobePath); err != nil {
-		return fmt.Errorf("ffprobe binary not found at %q: %w", c.FFprobePath, err)
+		return fmt.Errorf("ffprobe binary not found at %q: ensure ffprobe_path in config.json points to a valid binary: %w", c.FFprobePath, err)
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -76,14 +77,14 @@ func Load(path string) (*Config, error) {
 // It does not validate other configuration fields.
 func (c *Config) Validate() error {
 	if c.FFmpegPath == "" {
-		return fmt.Errorf("ffmpeg_path must not be empty")
+		return errors.New("ffmpeg_path must not be empty")
 	}
 	if _, err := exec.LookPath(c.FFmpegPath); err != nil {
 		return fmt.Errorf("ffmpeg binary not found at %q: ensure ffmpeg_path in config.json points to a valid binary: %w", c.FFmpegPath, err)
 	}
 
 	if c.FFprobePath == "" {
-		return fmt.Errorf("ffprobe_path must not be empty")
+		return errors.New("ffprobe_path must not be empty")
 	}
 	if _, err := exec.LookPath(c.FFprobePath); err != nil {
 		return fmt.Errorf("ffprobe binary not found at %q: ensure ffprobe_path in config.json points to a valid binary: %w", c.FFprobePath, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,12 +72,19 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
-// Validate checks whether the loaded configuration can be used at runtime.
+// Validate verifies that FFmpegPath and FFprobePath resolve via exec.LookPath.
+// It does not validate other configuration fields.
 func (c *Config) Validate() error {
+	if c.FFmpegPath == "" {
+		return fmt.Errorf("ffmpeg_path must not be empty")
+	}
 	if _, err := exec.LookPath(c.FFmpegPath); err != nil {
 		return fmt.Errorf("ffmpeg binary not found at %q: ensure ffmpeg_path in config.json points to a valid binary: %w", c.FFmpegPath, err)
 	}
 
+	if c.FFprobePath == "" {
+		return fmt.Errorf("ffprobe_path must not be empty")
+	}
 	if _, err := exec.LookPath(c.FFprobePath); err != nil {
 		return fmt.Errorf("ffprobe binary not found at %q: ensure ffprobe_path in config.json points to a valid binary: %w", c.FFprobePath, err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/oszuidwest/zwfm-audiologger/internal/constants"
 )
@@ -15,6 +16,8 @@ type Config struct {
 	Port          int                `json:"port"`
 	KeepDays      int                `json:"keep_days"`
 	Timezone      string             `json:"timezone"`
+	FFmpegPath    string             `json:"ffmpeg_path"`
+	FFprobePath   string             `json:"ffprobe_path"`
 	Stations      map[string]Station `json:"stations"`
 	Validation    *ValidationConfig  `json:"validation,omitempty"`
 }
@@ -69,6 +72,19 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
+// Validate checks whether the loaded configuration can be used at runtime.
+func (c *Config) Validate() error {
+	if _, err := exec.LookPath(c.FFmpegPath); err != nil {
+		return fmt.Errorf("ffmpeg binary not found at %q: %w", c.FFmpegPath, err)
+	}
+
+	if _, err := exec.LookPath(c.FFprobePath); err != nil {
+		return fmt.Errorf("ffprobe binary not found at %q: %w", c.FFprobePath, err)
+	}
+
+	return nil
+}
+
 func (c *Config) applyDefaults() {
 	if c.RecordingsDir == "" {
 		c.RecordingsDir = constants.DefaultRecordingsDir
@@ -81,6 +97,12 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Timezone == "" {
 		c.Timezone = constants.DefaultTimezone
+	}
+	if c.FFmpegPath == "" {
+		c.FFmpegPath = constants.DefaultFFmpegPath
+	}
+	if c.FFprobePath == "" {
+		c.FFprobePath = constants.DefaultFFprobePath
 	}
 
 	if c.Validation != nil && c.Validation.Enabled {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -87,27 +87,84 @@ func TestValidateAcceptsConfiguredBinaries(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsBinariesFromPATH(t *testing.T) {
+	dir := t.TempDir()
+	writeExecutable(t, filepath.Join(dir, "ffmpeg"))
+	writeExecutable(t, filepath.Join(dir, "ffprobe"))
+	t.Setenv("PATH", dir)
+
+	cfg := &Config{
+		FFmpegPath:  "ffmpeg",
+		FFprobePath: "ffprobe",
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+}
+
+func TestValidateRequiresConfiguredPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  *Config
+		want string
+	}{
+		{
+			name: "empty ffmpeg path",
+			cfg:  &Config{FFprobePath: validExecutablePath(t)},
+			want: "ffmpeg_path must not be empty",
+		},
+		{
+			name: "empty ffprobe path",
+			cfg:  &Config{FFmpegPath: validExecutablePath(t)},
+			want: "ffprobe_path must not be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cfg.Validate()
+			assertErrorContains(t, err, tt.want)
+		})
+	}
+}
+
 func TestValidateRequiresFFmpeg(t *testing.T) {
 	t.Parallel()
 
 	cfg := validTestConfig(t)
-	cfg.FFmpegPath = "/definitely/missing/ffmpeg"
+	cfg.FFmpegPath = filepath.Join(t.TempDir(), "missing-ffmpeg")
 
 	err := cfg.Validate()
-	assertErrorContains(t, err, "ffmpeg binary not found", "/definitely/missing/ffmpeg", "ffmpeg_path")
+	assertErrorContains(t, err, "ffmpeg binary not found", cfg.FFmpegPath, "ffmpeg_path")
 }
 
 func TestValidateRequiresFFprobe(t *testing.T) {
 	t.Parallel()
 
 	cfg := validTestConfig(t)
-	cfg.FFprobePath = "/definitely/missing/ffprobe"
+	cfg.FFprobePath = filepath.Join(t.TempDir(), "missing-ffprobe")
 
 	err := cfg.Validate()
-	assertErrorContains(t, err, "ffprobe binary not found", "/definitely/missing/ffprobe", "ffprobe_path")
+	assertErrorContains(t, err, "ffprobe binary not found", cfg.FFprobePath, "ffprobe_path")
 }
 
 func validTestConfig(t *testing.T) *Config {
+	t.Helper()
+
+	executablePath := validExecutablePath(t)
+
+	return &Config{
+		FFmpegPath:  executablePath,
+		FFprobePath: executablePath,
+	}
+}
+
+func validExecutablePath(t *testing.T) string {
 	t.Helper()
 
 	executablePath, err := os.Executable()
@@ -115,9 +172,15 @@ func validTestConfig(t *testing.T) *Config {
 		t.Fatalf("test executable path: %v", err)
 	}
 
-	return &Config{
-		FFmpegPath:  executablePath,
-		FFprobePath: executablePath,
+	return executablePath
+}
+
+func writeExecutable(t *testing.T, path string) {
+	t.Helper()
+
+	data := []byte("#!/bin/sh\nexit 0\n")
+	if err := os.WriteFile(path, data, 0o700); err != nil { //nolint:gosec // Test executable is written under t.TempDir().
+		t.Fatalf("write executable %s: %v", path, err)
 	}
 }
 
@@ -128,9 +191,14 @@ func assertErrorContains(t *testing.T, err error, parts ...string) {
 		t.Fatal("expected error")
 	}
 
+	failed := false
 	for _, part := range parts {
 		if !strings.Contains(err.Error(), part) {
-			t.Fatalf("expected error to contain %q, got: %v", part, err)
+			t.Errorf("expected error to contain %q, got: %v", part, err)
+			failed = true
 		}
+	}
+	if failed {
+		t.FailNow()
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/oszuidwest/zwfm-audiologger/internal/constants"
@@ -42,6 +43,12 @@ func TestLoadAppliesDefaultsAndParsesStations(t *testing.T) {
 	if cfg.Timezone != constants.DefaultTimezone {
 		t.Errorf("Timezone = %q, want %q", cfg.Timezone, constants.DefaultTimezone)
 	}
+	if cfg.FFmpegPath != constants.DefaultFFmpegPath {
+		t.Errorf("FFmpegPath = %q, want %q", cfg.FFmpegPath, constants.DefaultFFmpegPath)
+	}
+	if cfg.FFprobePath != constants.DefaultFFprobePath {
+		t.Errorf("FFprobePath = %q, want %q", cfg.FFprobePath, constants.DefaultFFprobePath)
+	}
 
 	station := cfg.Stations["station1"]
 	if station.StreamURL != "https://stream.example.com/station1.mp3" {
@@ -67,5 +74,52 @@ func TestLoadRejectsUnknownFields(t *testing.T) {
 
 	if _, err := Load(configPath); err == nil {
 		t.Fatal("Load returned nil error for config with an unknown field")
+	}
+}
+
+func TestValidateAcceptsConfiguredBinaries(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		FFmpegPath:  os.Args[0],
+		FFprobePath: os.Args[0],
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+}
+
+func TestValidateRequiresFFmpeg(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		FFmpegPath:  "/definitely/missing/ffmpeg",
+		FFprobePath: os.Args[0],
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate returned nil error")
+	}
+	if !strings.Contains(err.Error(), "ffmpeg binary not found") {
+		t.Fatalf("Validate error = %v, want ffmpeg error", err)
+	}
+}
+
+func TestValidateRequiresFFprobe(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		FFmpegPath:  os.Args[0],
+		FFprobePath: "/definitely/missing/ffprobe",
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate returned nil error")
+	}
+	if !strings.Contains(err.Error(), "ffprobe binary not found") {
+		t.Fatalf("Validate error = %v, want ffprobe error", err)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -80,10 +80,7 @@ func TestLoadRejectsUnknownFields(t *testing.T) {
 func TestValidateAcceptsConfiguredBinaries(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Config{
-		FFmpegPath:  os.Args[0],
-		FFprobePath: os.Args[0],
-	}
+	cfg := validTestConfig(t)
 
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate returned error: %v", err)
@@ -93,33 +90,47 @@ func TestValidateAcceptsConfiguredBinaries(t *testing.T) {
 func TestValidateRequiresFFmpeg(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Config{
-		FFmpegPath:  "/definitely/missing/ffmpeg",
-		FFprobePath: os.Args[0],
-	}
+	cfg := validTestConfig(t)
+	cfg.FFmpegPath = "/definitely/missing/ffmpeg"
 
 	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("Validate returned nil error")
-	}
-	if !strings.Contains(err.Error(), "ffmpeg binary not found") {
-		t.Fatalf("Validate error = %v, want ffmpeg error", err)
-	}
+	assertErrorContains(t, err, "ffmpeg binary not found", "/definitely/missing/ffmpeg", "ffmpeg_path")
 }
 
 func TestValidateRequiresFFprobe(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Config{
-		FFmpegPath:  os.Args[0],
-		FFprobePath: "/definitely/missing/ffprobe",
-	}
+	cfg := validTestConfig(t)
+	cfg.FFprobePath = "/definitely/missing/ffprobe"
 
 	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("Validate returned nil error")
+	assertErrorContains(t, err, "ffprobe binary not found", "/definitely/missing/ffprobe", "ffprobe_path")
+}
+
+func validTestConfig(t *testing.T) *Config {
+	t.Helper()
+
+	executablePath, err := os.Executable()
+	if err != nil {
+		t.Fatalf("test executable path: %v", err)
 	}
-	if !strings.Contains(err.Error(), "ffprobe binary not found") {
-		t.Fatalf("Validate error = %v, want ffprobe error", err)
+
+	return &Config{
+		FFmpegPath:  executablePath,
+		FFprobePath: executablePath,
+	}
+}
+
+func assertErrorContains(t *testing.T, err error, parts ...string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	for _, part := range parts {
+		if !strings.Contains(err.Error(), part) {
+			t.Fatalf("expected error to contain %q, got: %v", part, err)
+		}
 	}
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -24,6 +24,10 @@ const (
 	DefaultPort = 8080
 	// DefaultTimezone is the default timezone for the application.
 	DefaultTimezone = "UTC"
+	// DefaultFFmpegPath is the default FFmpeg executable path.
+	DefaultFFmpegPath = "ffmpeg"
+	// DefaultFFprobePath is the default ffprobe executable path.
+	DefaultFFprobePath = "ffprobe"
 
 	// DirPermissions defines the file mode for created directories.
 	DirPermissions = 0o755

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -24,9 +24,9 @@ const (
 	DefaultPort = 8080
 	// DefaultTimezone is the default timezone for the application.
 	DefaultTimezone = "UTC"
-	// DefaultFFmpegPath is the default FFmpeg executable path.
+	// DefaultFFmpegPath is the default FFmpeg executable name, resolved via PATH.
 	DefaultFFmpegPath = "ffmpeg"
-	// DefaultFFprobePath is the default ffprobe executable path.
+	// DefaultFFprobePath is the default ffprobe executable name, resolved via PATH.
 	DefaultFFprobePath = "ffprobe"
 
 	// DirPermissions defines the file mode for created directories.

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -50,8 +50,10 @@ func New(cfg *config.Config, validator Validator, notifier Notifier) *Manager {
 		metadataFetcher: metadata.New(),
 		validator:       validator,
 		notifier:        notifier,
-		recordCommand:   utils.RecordCommand,
-		availableBytes:  utils.AvailableDiskBytes,
+		recordCommand: func(ctx context.Context, streamURL string, duration time.Duration, outputFile string) *exec.Cmd {
+			return utils.RecordCommand(ctx, cfg.FFmpegPath, streamURL, duration, outputFile)
+		},
+		availableBytes: utils.AvailableDiskBytes,
 	}
 }
 
@@ -175,11 +177,11 @@ func (m *Manager) record(ctx context.Context, opts recordOptions) {
 	}
 
 	// Detect format from the recorded file and remux to proper container
-	format := utils.Format(tempFile)
+	format := utils.Format(m.config.FFprobePath, tempFile)
 	finalFile := utils.RecordingPath(m.config.RecordingsDir, name, timestamp, format)
 
 	// Remux the .mkv file to proper container format
-	remuxCmd := utils.RemuxCommand(tempFile, finalFile)
+	remuxCmd := utils.RemuxCommand(m.config.FFmpegPath, tempFile, finalFile)
 	remuxOutput, err := remuxCmd.CombinedOutput()
 	if err != nil {
 		// Limit output to first 500 bytes to avoid excessive logging

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -178,7 +178,19 @@ func (m *Manager) record(ctx context.Context, opts recordOptions) {
 	}
 
 	// Detect format from the recorded file and remux to proper container
-	format := utils.Format(m.config.FFprobePath, tempFile)
+	format, err := utils.Format(m.config.FFprobePath, tempFile)
+	if err != nil {
+		reason := fmt.Sprintf("format detection failed: %v", err)
+		slog.Error("failed to detect recording format",
+			"station", name,
+			"temp_file", tempFile,
+			"error", err,
+		)
+		if m.notifier != nil {
+			m.notifier.NotifyRecordingFailure(name, reason)
+		}
+		return
+	}
 	finalFile := utils.RecordingPath(m.config.RecordingsDir, name, timestamp, format)
 
 	// Remux the .mkv file to proper container format

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -50,6 +50,7 @@ func New(cfg *config.Config, validator Validator, notifier Notifier) *Manager {
 		metadataFetcher: metadata.New(),
 		validator:       validator,
 		notifier:        notifier,
+		// Capture cfg here so tests can replace recordCommand without changing production config lookup.
 		recordCommand: func(ctx context.Context, streamURL string, duration time.Duration, outputFile string) *exec.Cmd {
 			return utils.RecordCommand(ctx, cfg.FFmpegPath, streamURL, duration, outputFile)
 		},

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -15,11 +16,21 @@ import (
 )
 
 type recordingFailureNotifier struct {
-	calls atomic.Int32
+	calls  atomic.Int32
+	reason atomic.Value
 }
 
-func (n *recordingFailureNotifier) NotifyRecordingFailure(_, _ string) {
+func (n *recordingFailureNotifier) NotifyRecordingFailure(_, reason string) {
 	n.calls.Add(1)
+	n.reason.Store(reason)
+}
+
+func (n *recordingFailureNotifier) lastReason() string {
+	reason := n.reason.Load()
+	if reason == nil {
+		return ""
+	}
+	return reason.(string)
 }
 
 func TestScheduledAndCatchupDoNotNotifyOnParentContextCancellation(t *testing.T) {
@@ -148,6 +159,59 @@ printf remuxed > "$1"
 	finalFile := utils.RecordingPath(recordingsDir, "station", timestamp, ".aac")
 	if _, err := os.Stat(finalFile); err != nil {
 		t.Fatalf("final recording not written at detected format path: %v", err)
+	}
+}
+
+func TestRecordNotifiesAndKeepsTempFileWhenFormatDetectionFails(t *testing.T) {
+	recordingsDir := t.TempDir()
+	binDir := t.TempDir()
+	ffprobePath := filepath.Join(binDir, "ffprobe")
+	ffmpegPath := filepath.Join(binDir, "ffmpeg")
+	remuxMarker := filepath.Join(binDir, "remux.marker")
+	t.Setenv("FAKE_FFMPEG_MARKER", remuxMarker)
+
+	writeShellScript(t, ffprobePath, "#!/bin/sh\nexit 1\n")
+	writeShellScript(t, ffmpegPath, `#!/bin/sh
+printf remux > "$FAKE_FFMPEG_MARKER"
+exit 0
+`)
+
+	notifier := &recordingFailureNotifier{}
+	manager := New(&config.Config{
+		RecordingsDir: recordingsDir,
+		FFmpegPath:    ffmpegPath,
+		FFprobePath:   ffprobePath,
+	}, nil, notifier)
+	manager.recordCommand = func(ctx context.Context, _ string, _ time.Duration, outputFile string) *exec.Cmd {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestRecorderHelperProcess", "--", outputFile) //nolint:gosec // Test helper process and temp output path are controlled by this test.
+		cmd.Env = append(os.Environ(), "GO_WANT_RECORDER_WRITE_HELPER_PROCESS=1")
+		return cmd
+	}
+	manager.availableBytes = func(string) (uint64, error) {
+		return constants.MinDiskSpaceBytes, nil
+	}
+
+	const timestamp = "2026-04-30-23"
+	manager.record(context.Background(), recordOptions{
+		name:      "station",
+		station:   &config.Station{StreamURL: "https://stream.example.com/station.mp3"},
+		timestamp: timestamp,
+		duration:  time.Second,
+		timeout:   5 * time.Second,
+	})
+
+	if got := notifier.calls.Load(); got != 1 {
+		t.Fatalf("NotifyRecordingFailure calls = %d, want 1", got)
+	}
+	if reason := notifier.lastReason(); !strings.Contains(reason, "format detection failed") {
+		t.Fatalf("NotifyRecordingFailure reason = %q, want format detection failure", reason)
+	}
+	tempFile := utils.RecordingPath(recordingsDir, "station", timestamp, ".mkv")
+	if _, err := os.Stat(tempFile); err != nil {
+		t.Fatalf("temporary recording was not kept after format detection failure: %v", err)
+	}
+	if _, err := os.Stat(remuxMarker); !os.IsNotExist(err) {
+		t.Fatalf("remux command ran after format detection failure; stat error: %v", err)
 	}
 }
 

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -94,6 +94,63 @@ func TestScheduledAndCatchupDoNotNotifyOnParentContextCancellation(t *testing.T)
 	}
 }
 
+func TestRecordUsesConfiguredProbeAndRemuxPaths(t *testing.T) {
+	recordingsDir := t.TempDir()
+	binDir := t.TempDir()
+	ffprobePath := filepath.Join(binDir, "ffprobe")
+	ffmpegPath := filepath.Join(binDir, "ffmpeg")
+	probeMarker := filepath.Join(binDir, "probe.marker")
+	remuxMarker := filepath.Join(binDir, "remux.marker")
+	t.Setenv("FAKE_FFPROBE_MARKER", probeMarker)
+	t.Setenv("FAKE_FFMPEG_MARKER", remuxMarker)
+
+	writeShellScript(t, ffprobePath, `#!/bin/sh
+printf probe > "$FAKE_FFPROBE_MARKER"
+printf '%s\n' '{"streams":[{"codec_name":"aac"}]}'
+`)
+	writeShellScript(t, ffmpegPath, `#!/bin/sh
+printf remux > "$FAKE_FFMPEG_MARKER"
+while [ "$#" -gt 1 ]; do
+	shift
+done
+printf remuxed > "$1"
+`)
+
+	manager := New(&config.Config{
+		RecordingsDir: recordingsDir,
+		FFmpegPath:    ffmpegPath,
+		FFprobePath:   ffprobePath,
+	}, nil, nil)
+	manager.recordCommand = func(ctx context.Context, _ string, _ time.Duration, outputFile string) *exec.Cmd {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestRecorderHelperProcess", "--", outputFile) //nolint:gosec // Test helper process and temp output path are controlled by this test.
+		cmd.Env = append(os.Environ(), "GO_WANT_RECORDER_WRITE_HELPER_PROCESS=1")
+		return cmd
+	}
+	manager.availableBytes = func(string) (uint64, error) {
+		return constants.MinDiskSpaceBytes, nil
+	}
+
+	const timestamp = "2026-04-30-23"
+	manager.record(context.Background(), recordOptions{
+		name:      "station",
+		station:   &config.Station{StreamURL: "https://stream.example.com/station.aac"},
+		timestamp: timestamp,
+		duration:  time.Second,
+		timeout:   5 * time.Second,
+	})
+
+	if _, err := os.Stat(probeMarker); err != nil {
+		t.Fatalf("configured ffprobe was not executed: %v", err)
+	}
+	if _, err := os.Stat(remuxMarker); err != nil {
+		t.Fatalf("configured ffmpeg was not executed for remux: %v", err)
+	}
+	finalFile := utils.RecordingPath(recordingsDir, "station", timestamp, ".aac")
+	if _, err := os.Stat(finalFile); err != nil {
+		t.Fatalf("final recording not written at detected format path: %v", err)
+	}
+}
+
 func waitForFile(t *testing.T, path string) {
 	t.Helper()
 
@@ -108,7 +165,9 @@ func waitForFile(t *testing.T, path string) {
 }
 
 func TestRecorderHelperProcess(t *testing.T) {
-	if os.Getenv("GO_WANT_RECORDER_HELPER_PROCESS") != "1" {
+	shouldSleep := os.Getenv("GO_WANT_RECORDER_HELPER_PROCESS") == "1"
+	shouldExit := os.Getenv("GO_WANT_RECORDER_WRITE_HELPER_PROCESS") == "1"
+	if !shouldSleep && !shouldExit {
 		return
 	}
 
@@ -123,5 +182,16 @@ func TestRecorderHelperProcess(t *testing.T) {
 		os.Exit(2)
 	}
 
+	if shouldExit {
+		os.Exit(0)
+	}
 	time.Sleep(24 * time.Hour)
+}
+
+func writeShellScript(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o700); err != nil { //nolint:gosec // Test executable is written under t.TempDir().
+		t.Fatalf("write shell script %s: %v", path, err)
+	}
 }

--- a/internal/utils/ffmpeg.go
+++ b/internal/utils/ffmpeg.go
@@ -10,7 +10,7 @@ import (
 
 // RecordCommand creates an FFmpeg command for recording audio streams with
 // built-in reconnection support and timeout handling.
-func RecordCommand(ctx context.Context, streamURL string, duration time.Duration, outputFile string) *exec.Cmd {
+func RecordCommand(ctx context.Context, ffmpegPath, streamURL string, duration time.Duration, outputFile string) *exec.Cmd {
 	args := []string{
 		"-reconnect", "1", // Enable reconnection
 		"-reconnect_streamed", "1", // Reconnect even for streamed protocols
@@ -22,15 +22,15 @@ func RecordCommand(ctx context.Context, streamURL string, duration time.Duration
 		"-y", outputFile,
 	}
 
-	cmd := exec.CommandContext(ctx, "ffmpeg", args...) //nolint:gosec // Arguments are constructed from trusted config values
+	cmd := exec.CommandContext(ctx, ffmpegPath, args...) //nolint:gosec // Binary path is validated at startup; arguments are constructed from trusted config values.
 
 	return cmd
 }
 
 // RemuxCommand creates an FFmpeg command for remuxing a file to the proper container format
 // based on the output file extension, using stream copy for fast, lossless operation.
-func RemuxCommand(inputFile, outputFile string) *exec.Cmd {
-	return exec.Command("ffmpeg", //nolint:gosec // G204: args are from internal file paths, not user HTTP input
+func RemuxCommand(ffmpegPath, inputFile, outputFile string) *exec.Cmd {
+	return exec.Command(ffmpegPath, //nolint:gosec // Binary path is validated at startup; args are from internal file paths, not user HTTP input.
 		"-i", inputFile,
 		"-c", "copy",
 		"-y", outputFile,
@@ -38,8 +38,8 @@ func RemuxCommand(inputFile, outputFile string) *exec.Cmd {
 }
 
 // ProbeCommand creates an ffprobe command to get file metadata as JSON.
-func ProbeCommand(ctx context.Context, file string) *exec.Cmd {
-	return exec.CommandContext(ctx, "ffprobe", //nolint:gosec // G204: args are from internal file paths
+func ProbeCommand(ctx context.Context, ffprobePath, file string) *exec.Cmd {
+	return exec.CommandContext(ctx, ffprobePath, //nolint:gosec // Binary path is validated at startup; args are from internal file paths.
 		"-v", "quiet",
 		"-print_format", "json",
 		"-show_format",
@@ -48,8 +48,8 @@ func ProbeCommand(ctx context.Context, file string) *exec.Cmd {
 }
 
 // SilenceDetectCommand creates an FFmpeg command for silence detection.
-func SilenceDetectCommand(ctx context.Context, file string, thresholdDB int, minDurationSecs float64) *exec.Cmd {
-	return exec.CommandContext(ctx, "ffmpeg", //nolint:gosec // G204: args are from internal file paths
+func SilenceDetectCommand(ctx context.Context, ffmpegPath, file string, thresholdDB int, minDurationSecs float64) *exec.Cmd {
+	return exec.CommandContext(ctx, ffmpegPath, //nolint:gosec // Binary path is validated at startup; args are from internal file paths.
 		"-i", file,
 		"-af", fmt.Sprintf("silencedetect=noise=%ddB:d=%.1f", thresholdDB, minDurationSecs),
 		"-f", "null",
@@ -58,8 +58,8 @@ func SilenceDetectCommand(ctx context.Context, file string, thresholdDB int, min
 }
 
 // AudioStatsCommand creates an FFmpeg command for audio statistics extraction.
-func AudioStatsCommand(ctx context.Context, file string) *exec.Cmd {
-	return exec.CommandContext(ctx, "ffmpeg", //nolint:gosec // G204: args are from internal file paths
+func AudioStatsCommand(ctx context.Context, ffmpegPath, file string) *exec.Cmd {
+	return exec.CommandContext(ctx, ffmpegPath, //nolint:gosec // Binary path is validated at startup; args are from internal file paths.
 		"-i", file,
 		"-af", "astats=metadata=1:reset=1,ametadata=print:file=-",
 		"-f", "null",

--- a/internal/utils/ffmpeg.go
+++ b/internal/utils/ffmpeg.go
@@ -10,6 +10,7 @@ import (
 
 // RecordCommand creates an FFmpeg command for recording audio streams with
 // built-in reconnection support and timeout handling.
+// ffmpegPath must be a resolvable executable; the caller is responsible for validation.
 func RecordCommand(ctx context.Context, ffmpegPath, streamURL string, duration time.Duration, outputFile string) *exec.Cmd {
 	args := []string{
 		"-reconnect", "1", // Enable reconnection
@@ -22,15 +23,18 @@ func RecordCommand(ctx context.Context, ffmpegPath, streamURL string, duration t
 		"-y", outputFile,
 	}
 
-	cmd := exec.CommandContext(ctx, ffmpegPath, args...) //nolint:gosec // Binary path is validated at startup; arguments are constructed from trusted config values.
+	//nolint:gosec // ffmpegPath comes from operator-controlled config; arguments use trusted config/internal values.
+	cmd := exec.CommandContext(ctx, ffmpegPath, args...)
 
 	return cmd
 }
 
 // RemuxCommand creates an FFmpeg command for remuxing a file to the proper container format
 // based on the output file extension, using stream copy for fast, lossless operation.
+// ffmpegPath must be a resolvable executable; the caller is responsible for validation.
 func RemuxCommand(ffmpegPath, inputFile, outputFile string) *exec.Cmd {
-	return exec.Command(ffmpegPath, //nolint:gosec // Binary path is validated at startup; args are from internal file paths, not user HTTP input.
+	//nolint:gosec // ffmpegPath comes from operator-controlled config; args are internal file paths.
+	return exec.Command(ffmpegPath,
 		"-i", inputFile,
 		"-c", "copy",
 		"-y", outputFile,
@@ -38,8 +42,10 @@ func RemuxCommand(ffmpegPath, inputFile, outputFile string) *exec.Cmd {
 }
 
 // ProbeCommand creates an ffprobe command to get file metadata as JSON.
+// ffprobePath must be a resolvable executable; the caller is responsible for validation.
 func ProbeCommand(ctx context.Context, ffprobePath, file string) *exec.Cmd {
-	return exec.CommandContext(ctx, ffprobePath, //nolint:gosec // Binary path is validated at startup; args are from internal file paths.
+	//nolint:gosec // ffprobePath comes from operator-controlled config; args are internal file paths.
+	return exec.CommandContext(ctx, ffprobePath,
 		"-v", "quiet",
 		"-print_format", "json",
 		"-show_format",
@@ -48,8 +54,10 @@ func ProbeCommand(ctx context.Context, ffprobePath, file string) *exec.Cmd {
 }
 
 // SilenceDetectCommand creates an FFmpeg command for silence detection.
+// ffmpegPath must be a resolvable executable; the caller is responsible for validation.
 func SilenceDetectCommand(ctx context.Context, ffmpegPath, file string, thresholdDB int, minDurationSecs float64) *exec.Cmd {
-	return exec.CommandContext(ctx, ffmpegPath, //nolint:gosec // Binary path is validated at startup; args are from internal file paths.
+	//nolint:gosec // ffmpegPath comes from operator-controlled config; args are internal file paths.
+	return exec.CommandContext(ctx, ffmpegPath,
 		"-i", file,
 		"-af", fmt.Sprintf("silencedetect=noise=%ddB:d=%.1f", thresholdDB, minDurationSecs),
 		"-f", "null",
@@ -58,8 +66,10 @@ func SilenceDetectCommand(ctx context.Context, ffmpegPath, file string, threshol
 }
 
 // AudioStatsCommand creates an FFmpeg command for audio statistics extraction.
+// ffmpegPath must be a resolvable executable; the caller is responsible for validation.
 func AudioStatsCommand(ctx context.Context, ffmpegPath, file string) *exec.Cmd {
-	return exec.CommandContext(ctx, ffmpegPath, //nolint:gosec // Binary path is validated at startup; args are from internal file paths.
+	//nolint:gosec // ffmpegPath comes from operator-controlled config; args are internal file paths.
+	return exec.CommandContext(ctx, ffmpegPath,
 		"-i", file,
 		"-af", "astats=metadata=1:reset=1,ametadata=print:file=-",
 		"-f", "null",

--- a/internal/utils/ffmpeg_test.go
+++ b/internal/utils/ffmpeg_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"os/exec"
 	"testing"
 	"time"
 )
@@ -11,32 +12,32 @@ func TestFFmpegCommandPaths(t *testing.T) {
 
 	tests := []struct {
 		name string
-		got  string
+		cmd  *exec.Cmd
 		want string
 	}{
 		{
 			name: "record",
-			got:  RecordCommand(context.Background(), "/custom/ffmpeg", "https://stream.example.com", time.Second, "out.mkv").Args[0],
+			cmd:  RecordCommand(context.Background(), "/custom/ffmpeg", "https://stream.example.com", time.Second, "out.mkv"),
 			want: "/custom/ffmpeg",
 		},
 		{
 			name: "remux",
-			got:  RemuxCommand("/custom/ffmpeg", "in.mkv", "out.mp3").Args[0],
+			cmd:  RemuxCommand("/custom/ffmpeg", "in.mkv", "out.mp3"),
 			want: "/custom/ffmpeg",
 		},
 		{
 			name: "probe",
-			got:  ProbeCommand(context.Background(), "/custom/ffprobe", "in.mp3").Args[0],
+			cmd:  ProbeCommand(context.Background(), "/custom/ffprobe", "in.mp3"),
 			want: "/custom/ffprobe",
 		},
 		{
 			name: "silence detect",
-			got:  SilenceDetectCommand(context.Background(), "/custom/ffmpeg", "in.mp3", -40, 5).Args[0],
+			cmd:  SilenceDetectCommand(context.Background(), "/custom/ffmpeg", "in.mp3", -40, 5),
 			want: "/custom/ffmpeg",
 		},
 		{
 			name: "audio stats",
-			got:  AudioStatsCommand(context.Background(), "/custom/ffmpeg", "in.mp3").Args[0],
+			cmd:  AudioStatsCommand(context.Background(), "/custom/ffmpeg", "in.mp3"),
 			want: "/custom/ffmpeg",
 		},
 	}
@@ -45,8 +46,11 @@ func TestFFmpegCommandPaths(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if tt.got != tt.want {
-				t.Fatalf("command path = %q, want %q", tt.got, tt.want)
+			if tt.cmd.Args[0] != tt.want {
+				t.Errorf("Args[0] = %q, want %q", tt.cmd.Args[0], tt.want)
+			}
+			if tt.cmd.Path != tt.want {
+				t.Errorf("Path = %q, want %q", tt.cmd.Path, tt.want)
 			}
 		})
 	}

--- a/internal/utils/ffmpeg_test.go
+++ b/internal/utils/ffmpeg_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestFFmpegCommandPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "record",
+			got:  RecordCommand(context.Background(), "/custom/ffmpeg", "https://stream.example.com", time.Second, "out.mkv").Args[0],
+			want: "/custom/ffmpeg",
+		},
+		{
+			name: "remux",
+			got:  RemuxCommand("/custom/ffmpeg", "in.mkv", "out.mp3").Args[0],
+			want: "/custom/ffmpeg",
+		},
+		{
+			name: "probe",
+			got:  ProbeCommand(context.Background(), "/custom/ffprobe", "in.mp3").Args[0],
+			want: "/custom/ffprobe",
+		},
+		{
+			name: "silence detect",
+			got:  SilenceDetectCommand(context.Background(), "/custom/ffmpeg", "in.mp3", -40, 5).Args[0],
+			want: "/custom/ffmpeg",
+		},
+		{
+			name: "audio stats",
+			got:  AudioStatsCommand(context.Background(), "/custom/ffmpeg", "in.mp3").Args[0],
+			want: "/custom/ffmpeg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.got != tt.want {
+				t.Fatalf("command path = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/utils/format.go
+++ b/internal/utils/format.go
@@ -2,7 +2,8 @@ package utils
 
 import (
 	"encoding/json"
-	"log/slog"
+	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -15,10 +16,9 @@ type ProbeResult struct {
 }
 
 // Format uses ffprobe to detect the actual format of a recorded audio file.
-// It returns the appropriate file extension based on the detected codec,
-// defaulting to ".mp3" if detection fails.
+// It returns the appropriate file extension based on the detected codec.
 // ffprobePath must be a resolvable executable; the caller is responsible for validation.
-func Format(ffprobePath, filePath string) string {
+func Format(ffprobePath, filePath string) (string, error) {
 	// Run ffprobe on the file
 	//nolint:gosec // ffprobePath comes from operator-controlled config; args are internal file paths.
 	cmd := exec.Command(ffprobePath,
@@ -31,22 +31,19 @@ func Format(ffprobePath, filePath string) string {
 
 	output, err := cmd.Output()
 	if err != nil {
-		slog.Warn("ffprobe failed, defaulting to .mp3", "file", filePath, "error", err)
-		return ".mp3"
+		return "", fmt.Errorf("run ffprobe: %w", err)
 	}
 
 	var result ProbeResult
 	if err := json.Unmarshal(output, &result); err != nil {
-		slog.Warn("failed to parse ffprobe output, defaulting to .mp3", "file", filePath, "error", err)
-		return ".mp3"
+		return "", fmt.Errorf("parse ffprobe output: %w", err)
 	}
 
 	if len(result.Streams) > 0 {
-		return extensionForCodec(result.Streams[0].CodecName)
+		return extensionForCodec(result.Streams[0].CodecName), nil
 	}
 
-	slog.Warn("ffprobe returned no audio streams, defaulting to .mp3", "file", filePath)
-	return ".mp3" // Default fallback
+	return "", errors.New("ffprobe returned no audio streams")
 }
 
 func extensionForCodec(codecName string) string {

--- a/internal/utils/format.go
+++ b/internal/utils/format.go
@@ -17,9 +17,9 @@ type ProbeResult struct {
 // Format uses ffprobe to detect the actual format of a recorded audio file.
 // It returns the appropriate file extension based on the detected codec,
 // defaulting to ".mp3" if detection fails.
-func Format(filePath string) string {
+func Format(ffprobePath, filePath string) string {
 	// Run ffprobe on the file
-	cmd := exec.Command("ffprobe", //nolint:gosec // G204: args are from internal file paths, not user HTTP input
+	cmd := exec.Command(ffprobePath, //nolint:gosec // Binary path is validated at startup; args are from internal file paths, not user HTTP input.
 		"-v", "quiet",
 		"-print_format", "json",
 		"-show_streams",

--- a/internal/utils/format.go
+++ b/internal/utils/format.go
@@ -17,9 +17,11 @@ type ProbeResult struct {
 // Format uses ffprobe to detect the actual format of a recorded audio file.
 // It returns the appropriate file extension based on the detected codec,
 // defaulting to ".mp3" if detection fails.
+// ffprobePath must be a resolvable executable; the caller is responsible for validation.
 func Format(ffprobePath, filePath string) string {
 	// Run ffprobe on the file
-	cmd := exec.Command(ffprobePath, //nolint:gosec // Binary path is validated at startup; args are from internal file paths, not user HTTP input.
+	//nolint:gosec // ffprobePath comes from operator-controlled config; args are internal file paths.
+	cmd := exec.Command(ffprobePath,
 		"-v", "quiet",
 		"-print_format", "json",
 		"-show_streams",

--- a/internal/utils/format_test.go
+++ b/internal/utils/format_test.go
@@ -1,6 +1,10 @@
 package utils
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestExtensionForCodec(t *testing.T) {
 	tests := []struct {
@@ -28,6 +32,18 @@ func TestExtensionForCodec(t *testing.T) {
 				t.Errorf("extensionForCodec(%q) = %q, want %q", tt.codec, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFormatUsesConfiguredFFprobePath(t *testing.T) {
+	ffprobePath := filepath.Join(t.TempDir(), "fake-ffprobe")
+	script := "#!/bin/sh\nprintf '%s\\n' '{\"streams\":[{\"codec_name\":\"opus\"}]}'\n"
+	if err := os.WriteFile(ffprobePath, []byte(script), 0o700); err != nil { //nolint:gosec // Test executable is written under t.TempDir().
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
+
+	if got := Format(ffprobePath, "recording.mkv"); got != ".opus" {
+		t.Fatalf("Format() = %q, want %q", got, ".opus")
 	}
 }
 

--- a/internal/utils/format_test.go
+++ b/internal/utils/format_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -42,8 +43,56 @@ func TestFormatUsesConfiguredFFprobePath(t *testing.T) {
 		t.Fatalf("write fake ffprobe: %v", err)
 	}
 
-	if got := Format(ffprobePath, "recording.mkv"); got != ".opus" {
+	got, err := Format(ffprobePath, "recording.mkv")
+	if err != nil {
+		t.Fatalf("Format returned error: %v", err)
+	}
+	if got != ".opus" {
 		t.Fatalf("Format() = %q, want %q", got, ".opus")
+	}
+}
+
+func TestFormatReturnsErrorWhenFFprobeFails(t *testing.T) {
+	ffprobePath := filepath.Join(t.TempDir(), "fake-ffprobe")
+	if err := os.WriteFile(ffprobePath, []byte("#!/bin/sh\nexit 1\n"), 0o700); err != nil { //nolint:gosec // Test executable is written under t.TempDir().
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
+
+	format, err := Format(ffprobePath, "recording.mkv")
+	if err == nil {
+		t.Fatal("Format returned nil error")
+	}
+	if format != "" {
+		t.Fatalf("Format returned format %q, want empty", format)
+	}
+	if !strings.Contains(err.Error(), "run ffprobe") {
+		t.Fatalf("Format error = %v, want run ffprobe context", err)
+	}
+}
+
+func TestFormatReturnsErrorForInvalidFFprobeOutput(t *testing.T) {
+	ffprobePath := filepath.Join(t.TempDir(), "fake-ffprobe")
+	if err := os.WriteFile(ffprobePath, []byte("#!/bin/sh\nprintf 'not-json'\n"), 0o700); err != nil { //nolint:gosec // Test executable is written under t.TempDir().
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
+
+	if _, err := Format(ffprobePath, "recording.mkv"); err == nil {
+		t.Fatal("Format returned nil error")
+	} else if !strings.Contains(err.Error(), "parse ffprobe output") {
+		t.Fatalf("Format error = %v, want parse context", err)
+	}
+}
+
+func TestFormatReturnsErrorForNoAudioStreams(t *testing.T) {
+	ffprobePath := filepath.Join(t.TempDir(), "fake-ffprobe")
+	if err := os.WriteFile(ffprobePath, []byte("#!/bin/sh\nprintf '%s\\n' '{\"streams\":[]}'\n"), 0o700); err != nil { //nolint:gosec // Test executable is written under t.TempDir().
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
+
+	if _, err := Format(ffprobePath, "recording.mkv"); err == nil {
+		t.Fatal("Format returned nil error")
+	} else if !strings.Contains(err.Error(), "no audio streams") {
+		t.Fatalf("Format error = %v, want no audio streams context", err)
 	}
 }
 

--- a/internal/validator/analysis.go
+++ b/internal/validator/analysis.go
@@ -27,7 +27,7 @@ func (m *Manager) analyzeDuration(ctx context.Context, file string) (float64, er
 	ctx, cancel := context.WithTimeout(ctx, constants.ValidationAnalysisTimeout)
 	defer cancel()
 
-	cmd := utils.ProbeCommand(ctx, file)
+	cmd := utils.ProbeCommand(ctx, m.config.FFprobePath, file)
 	output, err := cmd.Output()
 	if err != nil {
 		return 0, fmt.Errorf("ffprobe failed: %w", err)
@@ -58,7 +58,7 @@ func (m *Manager) analyzeSilence(ctx context.Context, file string) (float64, err
 	thresholdDB := int(m.config.Validation.SilenceThresholdDB)
 	minDuration := m.config.Validation.MaxSilenceSecs
 
-	cmd := utils.SilenceDetectCommand(ctx, file, thresholdDB, minDuration)
+	cmd := utils.SilenceDetectCommand(ctx, m.config.FFmpegPath, file, thresholdDB, minDuration)
 
 	// silencedetect outputs to stderr.
 	var stderr bytes.Buffer
@@ -90,7 +90,7 @@ func (m *Manager) analyzeLoops(ctx context.Context, file string) (float64, error
 	ctx, cancel := context.WithTimeout(ctx, constants.ValidationAnalysisTimeout)
 	defer cancel()
 
-	cmd := utils.AudioStatsCommand(ctx, file)
+	cmd := utils.AudioStatsCommand(ctx, m.config.FFmpegPath, file)
 
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/validator/analysis_test.go
+++ b/internal/validator/analysis_test.go
@@ -1,0 +1,81 @@
+package validator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oszuidwest/zwfm-audiologger/internal/config"
+)
+
+func TestAnalyzeDurationUsesConfiguredFFprobePath(t *testing.T) {
+	ffprobePath := filepath.Join(t.TempDir(), "ffprobe")
+	writeAnalysisScript(t, ffprobePath, `#!/bin/sh
+printf '%s\n' '{"format":{"duration":"12.5"}}'
+`)
+
+	m := &Manager{config: &config.Config{FFprobePath: ffprobePath}}
+
+	got, err := m.analyzeDuration(context.Background(), "recording.mp3")
+	if err != nil {
+		t.Fatalf("analyzeDuration returned error: %v", err)
+	}
+	if got != 12.5 {
+		t.Fatalf("analyzeDuration = %v, want 12.5", got)
+	}
+}
+
+func TestAnalyzeSilenceUsesConfiguredFFmpegPath(t *testing.T) {
+	ffmpegPath := filepath.Join(t.TempDir(), "ffmpeg")
+	writeAnalysisScript(t, ffmpegPath, `#!/bin/sh
+printf '%s\n' 'silence_start: 1 silence_end: 7 silence_duration: 6' >&2
+exit 1
+`)
+
+	m := &Manager{config: &config.Config{
+		FFmpegPath: ffmpegPath,
+		Validation: &config.ValidationConfig{
+			SilenceThresholdDB: -40,
+			MaxSilenceSecs:     5,
+		},
+	}}
+
+	got, err := m.analyzeSilence(context.Background(), "recording.mp3")
+	if err != nil {
+		t.Fatalf("analyzeSilence returned error: %v", err)
+	}
+	if got != 6 {
+		t.Fatalf("analyzeSilence = %v, want 6", got)
+	}
+}
+
+func TestAnalyzeLoopsUsesConfiguredFFmpegPath(t *testing.T) {
+	ffmpegPath := filepath.Join(t.TempDir(), "ffmpeg")
+	writeAnalysisScript(t, ffmpegPath, `#!/bin/sh
+i=0
+while [ "$i" -lt 60 ]; do
+	printf '%s\n' 'RMS_level=-1'
+	i=$((i + 1))
+done
+exit 1
+`)
+
+	m := &Manager{config: &config.Config{FFmpegPath: ffmpegPath}}
+
+	got, err := m.analyzeLoops(context.Background(), "recording.mp3")
+	if err != nil {
+		t.Fatalf("analyzeLoops returned error: %v", err)
+	}
+	if got != 100 {
+		t.Fatalf("analyzeLoops = %v, want 100", got)
+	}
+}
+
+func writeAnalysisScript(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o700); err != nil { //nolint:gosec // Test executable is written under t.TempDir().
+		t.Fatalf("write analysis script %s: %v", path, err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -57,6 +57,10 @@ func main() {
 		slog.Error("failed to load config", "error", err)
 		os.Exit(1)
 	}
+	if err := cfg.Validate(); err != nil {
+		slog.Error("invalid config", "error", err)
+		os.Exit(1)
+	}
 
 	// Set the timezone from config
 	utils.SetTimezone(cfg.Timezone)


### PR DESCRIPTION
## Summary
- add configurable `ffmpeg_path` and `ffprobe_path` settings with existing `ffmpeg`/`ffprobe` defaults
- validate both tool paths at startup with clear empty-path errors and zwfm-babbel-style wrapped lookup failures
- route recording, remuxing, format detection, and validation commands through the configured paths, with regression tests for the wiring
- propagate format detection failures instead of silently falling back to `.mp3`; operators now get the normal recording-failure notification and the `.mkv` is retained for diagnosis
- document the new fields in README and config.json

## Size/runtime note
This keeps the Alpine runtime and existing BusyBox `wget` healthcheck unchanged. Local image size remained effectively the same: `63,835,812` bytes for `zwfm-audiologger:ffmpeg-paths-local`.

## Verification
- go test ./...
- go vet ./...
- golangci-lint run --timeout=5m
- go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
- hadolint --config .hadolint.yaml Dockerfile
- docker compose config --quiet
- docker build --pull -q -t zwfm-audiologger:ffmpeg-paths-local .
- docker run --rm --entrypoint sh zwfm-audiologger:ffmpeg-paths-local -c 'command -v ffmpeg && command -v ffprobe'
- docker run --rm zwfm-audiologger:ffmpeg-paths-local /app/audiologger -version

Latest local recheck after review cleanup:
- go test ./...
- golangci-lint run ./...