### PR TITLE
ci: clean up orphaned GHCR manifests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,19 @@ jobs:
     permissions:
       contents: read
       packages: write
+
+  cleanup:
+    needs: docker
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      # Every push of a rebuilt image orphans the previous manifest set
+      # (manifest list + per-arch children) as untagged versions. This
+      # deletes only truly unreferenced manifests; arch children of tagged
+      # manifest lists are preserved.
+      - name: Delete orphaned untagged images
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          packages: zwfm-audiologger
+          validate: true


### PR DESCRIPTION
## Summary
- add a cleanup job after the Docker publish job
- clean up orphaned untagged GHCR manifests for package `zwfm-audiologger`
- validate multi-arch manifests afterwards with `validate: true`

## Checks
- `actionlint .github/workflows/release.yml`
- `git diff --check`