### PR TITLE
build: bump Go to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine3.23 AS builder
+FROM golang:1.26.5-alpine3.23 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oszuidwest/zwfm-audiologger
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/dustin/go-humanize v1.0.1


### PR DESCRIPTION
## Summary
- bump the Go directive to `1.26.5`
- pin the Docker build image to `golang:1.26.5-alpine3.23`

## Checks
- `go mod tidy`
- `go test ./...`
- `go mod verify`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- `docker manifest inspect golang:1.26.5-alpine3.23`